### PR TITLE
fix:エラーに対応するために、dockerfileを修正しました

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /rails
 
 # Install base packages
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libjemalloc2 libvips postgresql-client && \
+    apt-get install --no-install-recommends -y curl libjemalloc2 libvips postgresql-client libyaml-dev && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Set production environment


### PR DESCRIPTION
# 概要

<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->
以下のエラーが発生し、検索したところ、以下の記事がヒットし、それに準じてDockerfileにlibyamlをインストールする記載を追加しました。
https://qiita.com/tatematsu-k/items/d68e19c8a90b2599baf2
https://stackoverflow.com/questions/78438698/an-error-occurred-while-installing-psych-5-1-2-and-bundler-cannot-continue

```
info
#16 91.90 
error
#16 91.90 An error occurred while installing psych (5.2.3), and Bundler cannot continue.
info
#16 91.90 
info
#16 91.90 In Gemfile:
info
#16 91.90   cssbundling-rails was resolved to 1.4.3, which depends on
info
#16 91.90     railties was resolved to 7.2.2.1, which depends on
info
#16 91.90       irb was resolved to 1.15.2, which depends on
info
#16 91.90         rdoc was resolved to 6.13.1, which depends on
info
#16 91.90           psych
error
#16 ERROR: process "/bin/sh -c bundle install &&     rm -rf ~/.bundle/ \"${BUNDLE_PATH}\"/ruby/*/cache \"${BUNDLE_PATH}\"/ruby/*/bundler/gems/*/.git &&     bundle exec bootsnap precompile --gemfile" did not complete successfully: exit code: 5
info
------
info
 > [build  4/10] RUN bundle install &&     rm -rf ~/.bundle/ "/usr/local/bundle"/ruby/*/cache "/usr/local/bundle"/ruby/*/bundler/gems/*/.git &&     bundle exec bootsnap precompile --gemfile:
info
91.90 `block (2 levels) in create_threads'
info
91.90 
error
91.90 An error occurred while installing psych (5.2.3), and Bundler cannot continue.
info
91.90 
info
91.90 In Gemfile:
info
91.90   cssbundling-rails was resolved to 1.4.3, which depends on
info
91.90     railties was resolved to 7.2.2.1, which depends on
info
91.90       irb was resolved to 1.15.2, which depends on
info
91.90         rdoc was resolved to 6.13.1, which depends on
info
91.90           psych
info
------
info
Dockerfile:44
info
--------------------
info
  43 |     COPY Gemfile Gemfile.lock ./
info
  44 | >>> RUN bundle install && \
info
  45 | >>>     rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git && \
info
  46 | >>>     bundle exec bootsnap precompile --gemfile
info
  47 |     
info
--------------------
error
error: failed to solve: process "/bin/sh -c bundle install &&     rm -rf ~/.bundle/ \"${BUNDLE_PATH}\"/ruby/*/cache \"${BUNDLE_PATH}\"/ruby/*/bundler/gems/*/.git &&     bundle exec bootsnap precompile --gemfile" did not complete successfully: exit code: 5
error
error: exit status 1
You can also use theRender CLIto explore logs in your command line.

Looking for more logs? Tr
```


# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイントです -->

- エラーはrubyのイメージからpsychが依存する複数のライブラリが削除されたことによるもの
- libyamlをapt installすることで解決する
- 以上のことから、Dockerfileでビルド時にlibyamlをインストールすることで解決を試みます

# 影響範囲・懸念点

<!-- レビュアーに見てほしい点、影響しそうな機能 -->
特になし

# おこなった動作確認

<!-- おこなった動作確認を箇条書きで。大きなUI変更は iOS Safari / Android Chrome での確認もすること -->
特になし


# その他

<!-- レビュアーへのメッセージや一言などあれば -->
特になし
