### PR TITLE
ユーザー編集画面を作製しました closes #15

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -20,9 +20,27 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # PUT /resource
-  # def update
-  #   super
-  # end
+  def update
+    self.resource = resource_class.to_adapter.get!(send(:"current_#{resource_name}").to_key)
+    prev_unconfirmed_email = resource.unconfirmed_email if resource.respond_to?(:unconfirmed_email)
+
+    resource_updated = update_resource(resource, account_update_params)
+    yield resource if block_given?
+    if resource_updated
+      set_flash_message_for_update(resource, prev_unconfirmed_email)
+      bypass_sign_in resource, scope: resource_name if sign_in_after_change_password?
+
+      respond_with resource, location: after_update_path_for(resource)
+    else
+      clean_up_passwords resource
+      set_minimum_password_length
+
+      @user = resource
+      @title = "ユーザーページ"
+      @modal_open = true
+      render "users/show", status: :unprocessable_entity
+    end
+  end
 
   # DELETE /resource
   # def destroy
@@ -47,12 +65,18 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # If you have extra params to permit, append them to the sanitizer.
   def configure_account_update_params
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :bio])
   end
 
   # The path used after sign up.
-  def after_sign_up_path_for(_resource)
+  # rubocop:disable Lint/UnusedMethodArgument
+  def after_sign_up_path_for(resource)
     user_check_path
+  end
+  # rubocop:enable Lint/UnusedMethodArgument
+
+  def after_update_path_for(resource)
+    user_path(resource)
   end
 
   # The path used after sign up for inactive accounts.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def current_user?(user)
+    user && user == current_user
+  end
 end

--- a/app/views/application/_flash.html.erb
+++ b/app/views/application/_flash.html.erb
@@ -1,0 +1,47 @@
+<% if flash[:notice] %>
+  <div role="alert" class="alert alert-success">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 shrink-0 stroke-current" fill="none" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+    <%= flash[:notice] %>
+
+    <!-- フラッシュメッセージ閉じるボタン -->
+    <button class="btn btn-sm btn-circle btn-ghost" onclick="this.parentElement.remove()">
+      <span class="material-symbols-outlined">
+        close
+      </span>
+    </button>
+  </div>
+<% end %>
+
+<% if flash[:alert] %>
+  <div role="alert" class="alert alert-warning">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 shrink-0 stroke-current" fill="none" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+    </svg>
+    <%= flash[:alert] %>
+
+    <!-- フラッシュメッセージ閉じるボタン -->
+    <button class="btn btn-sm btn-circle btn-ghost" onclick="this.parentElement.remove()">
+      <span class="material-symbols-outlined">
+        close
+      </span>
+    </button>
+  </div>
+<% end %>
+
+<% if flash[:error] %>
+  <div role="alert" class="alert alert-error">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 shrink-0 stroke-current" fill="none" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+    <%= flash[:error] %>
+
+    <!-- フラッシュメッセージ閉じるボタン -->
+    <button class="btn btn-sm btn-circle btn-ghost" onclick="this.parentElement.remove()">
+      <span class="material-symbols-outlined">
+        close
+      </span>
+    </button>
+  </div>
+<% end %>

--- a/app/views/devise/registrations/_edit_form_modal.html.erb
+++ b/app/views/devise/registrations/_edit_form_modal.html.erb
@@ -1,118 +1,114 @@
 <!-- @modal_openはregistrations_controller.rbで定義 -->
 <!-- update失敗時にrender users/showを行う際にモーダルが閉じてしまうことを回避 -->
-<% if @modal_open %>
-  <dialog id="edit_modal" class="modal" open>
-  <% else %>
-    <dialog id="edit_modal" class="modal">
-    <% end %>
-    <div class="modal-box">
-      <p class="pb-4 text-center">ESC or 下の(X)を押すと閉じます</p>
-      <div class="flex items-center justify-center">
-        <div class="card bg-base-300 w-2xl h-2xl p-5 flex justify-center z-10">
-          <div>
+<dialog id="edit_modal" class="modal" <%= @modal_open ? 'open' : ' ' %> >
+  <div class="modal-box">
+    <p class="pb-4 text-center">ESC or 下の(X)を押すと閉じます</p>
+    <div class="flex items-center justify-center">
+      <div class="card bg-base-300 w-2xl h-2xl p-5 flex justify-center z-10">
+        <div>
 
-            <!-- タイトルタブ -->
-            <div class="flex items-center justify-center text-secondary">
-                <p class="text-xl">ユーザー編集</p>
-            </div>
+          <!-- タイトルタブ -->
+          <div class="flex items-center justify-center text-secondary">
+            <p class="text-xl">ユーザー編集</p>
+          </div>
 
-            <!-- エラーメッセージ -->
-            <%= render "devise/shared/error_messages", resource: @user %>
+          <!-- エラーメッセージ -->
+          <%= render "devise/shared/error_messages", resource: @user %>
 
-            <!-- 編集フォーム -->
-            <%= form_for(@user, as: @user, url: registration_path(@user), html: { method: :put, class: "w-full mt-6" }) do |f| %>
+          <!-- 編集フォーム -->
+          <%= form_for(@user, as: @user, url: registration_path(@user), html: { method: :put, class: "w-full mt-6" }) do |f| %>
 
-              <div class="divider mb-4">プロフィール</div>
+            <div class="divider mb-4">プロフィール</div>
 
-              <label class="floating-label">
-                <%= f.text_field :name,
-                  autofocus: true,
-                  autocomplete: "name",
-                  placeholder: "User name",
-                  class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
-                  <span class="floating-label-text">Name</span>
-              </label>
+            <label class="floating-label">
+              <%= f.text_field :name,
+                autofocus: true,
+                autocomplete: "name",
+                placeholder: "User name",
+                class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
+                <span class="floating-label-text">Name</span>
+            </label>
 
-              <label class="floating-label mt-5">
-                <%= f.text_field :email,
-                  autocomplete: "email",
-                  placeholder: "Email address",
-                  class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
-                  <span class="floating-label-text">Email</span>
-              </label>
+            <label class="floating-label mt-5">
+              <%= f.text_field :email,
+                autocomplete: "email",
+                placeholder: "Email address",
+                class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
+                <span class="floating-label-text">Email</span>
+            </label>
 
-              <label class="floating-label mt-5">
-                <%= f.text_area :bio,
-                  autocomplete: "bio",
-                  placeholder: "Bio (optional)",
-                  class: "textarea textarea-lg input-primary w-full text-base-100 bg-base-200 rounded-lg" %>
-                  <span class="floating-label-text">Bio</span>
-              </label>
+            <label class="floating-label mt-5">
+              <%= f.text_area :bio,
+                autocomplete: "bio",
+                placeholder: "Bio (optional)",
+                class: "textarea textarea-lg input-primary w-full text-base-100 bg-base-200 rounded-lg" %>
+                <span class="floating-label-text">Bio</span>
+            </label>
 
-              <div class="divider mb-4 mt-10">パスワード変更時のみ入力</div>
+            <div class="divider mb-4 mt-10">パスワード変更時のみ入力</div>
 
-              <label class="floating-label mt-5">
-                <%= f.password_field :password,
-                  autocomplete: "new-password",
-                  placeholder: "New Password",
-                  class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
-                  <span class="floating-label-text">New Password</span>
-              </label>
+            <label class="floating-label mt-5">
+              <%= f.password_field :password,
+                autocomplete: "new-password",
+                placeholder: "New Password",
+                class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
+                <span class="floating-label-text">New Password</span>
+            </label>
 
-              <label class="floating-label mt-5">
-                <%= f.password_field :password_confirmation,
-                  autocomplete: "new-password",
-                  placeholder: "Confirm New Password",
-                  class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
-                  <span class="floating-label-text">Confirm New Password</span>
-              </label>
+            <label class="floating-label mt-5">
+              <%= f.password_field :password_confirmation,
+                autocomplete: "new-password",
+                placeholder: "Confirm New Password",
+                class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
+                <span class="floating-label-text">Confirm New Password</span>
+            </label>
 
-              <% if @minimum_password_length %>
-                <p class="mt-2 text-xs text-base-200">
-                <em><%= @minimum_password_length %> characters minimum</em>
-                </p>
-              <% end %>
-
-              <div class="divider mb-4 mt-10">パスワード</div>
-
-              <label class="floating-label mt-5">
-                <%= f.password_field :current_password,
-                  autocomplete: "current-password",
-                  placeholder: "Current Password (required)",
-                  class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
-                  <span class="floating-label-text">Current Password</span>
-              </label>
-              <p class="mt-1 text-xs text-base-200">
-              <em>※変更を確定するには現在のパスワードが必要です</em>
+            <% if @minimum_password_length %>
+              <p class="mt-2 text-xs text-base-200">
+              <em><%= @minimum_password_length %> characters minimum</em>
               </p>
-
-              <div class="mt-8">
-                <%= f.submit "保存",
-                  class:"btn btn-secondary w-full text-base-200" %>
-              </div>
             <% end %>
 
-            <div class="divider mb-4 mt-15">ユーザー削除</div>
+            <div class="divider mb-4 mt-10">パスワード</div>
 
-            <div class="flex flex-col items-center">
-              <%= button_to "アカウントを削除する", 
-                registration_path(@user), 
-                data: { confirm: "本当に削除しますか？", turbo_confirm: "本当に削除しますか？" }, 
-                method: :delete, 
-                class: "btn btn-error w-full" %>
+            <label class="floating-label mt-5">
+              <%= f.password_field :current_password,
+                autocomplete: "current-password",
+                placeholder: "Current Password (required)",
+                class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
+                <span class="floating-label-text">Current Password</span>
+            </label>
+            <p class="mt-1 text-xs text-base-200">
+            <em>※変更を確定するには現在のパスワードが必要です</em>
+            </p>
+
+            <div class="mt-8">
+              <%= f.submit "保存",
+                class:"btn btn-secondary w-full text-base-200" %>
             </div>
+          <% end %>
+
+          <div class="divider mb-4 mt-15">ユーザー削除</div>
+
+          <div class="flex flex-col items-center">
+            <%= button_to "アカウントを削除する", 
+              registration_path(@user), 
+              data: { confirm: "本当に削除しますか？", turbo_confirm: "本当に削除しますか？" }, 
+              method: :delete, 
+              class: "btn btn-error w-full" %>
           </div>
         </div>
       </div>
-      <div class="modal-action flex justify-center">
-        <form method="dialog">
-          <button class="btn btn-accent px-9">
-            <span class="material-symbols-outlined">
-              close
-            </span>
-          </button>
-        </form>
-      </div>
     </div>
+    <div class="modal-action flex justify-center">
+      <form method="dialog">
+        <button class="btn btn-accent px-9">
+          <span class="material-symbols-outlined">
+            close
+          </span>
+        </button>
+      </form>
+    </div>
+  </div>
 
-    </dialog>
+</dialog>

--- a/app/views/devise/registrations/_edit_form_modal.html.erb
+++ b/app/views/devise/registrations/_edit_form_modal.html.erb
@@ -1,0 +1,118 @@
+<!-- @modal_openはregistrations_controller.rbで定義 -->
+<!-- update失敗時にrender users/showを行う際にモーダルが閉じてしまうことを回避 -->
+<% if @modal_open %>
+  <dialog id="edit_modal" class="modal" open>
+  <% else %>
+    <dialog id="edit_modal" class="modal">
+    <% end %>
+    <div class="modal-box">
+      <p class="pb-4 text-center">ESC or 下の(X)を押すと閉じます</p>
+      <div class="flex items-center justify-center">
+        <div class="card bg-base-300 w-2xl h-2xl p-5 flex justify-center z-10">
+          <div>
+
+            <!-- タイトルタブ -->
+            <div class="flex items-center justify-center text-secondary">
+                <p class="text-xl">ユーザー編集</p>
+            </div>
+
+            <!-- エラーメッセージ -->
+            <%= render "devise/shared/error_messages", resource: @user %>
+
+            <!-- 編集フォーム -->
+            <%= form_for(@user, as: @user, url: registration_path(@user), html: { method: :put, class: "w-full mt-6" }) do |f| %>
+
+              <div class="divider mb-4">プロフィール</div>
+
+              <label class="floating-label">
+                <%= f.text_field :name,
+                  autofocus: true,
+                  autocomplete: "name",
+                  placeholder: "User name",
+                  class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
+                  <span class="floating-label-text">Name</span>
+              </label>
+
+              <label class="floating-label mt-5">
+                <%= f.text_field :email,
+                  autocomplete: "email",
+                  placeholder: "Email address",
+                  class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
+                  <span class="floating-label-text">Email</span>
+              </label>
+
+              <label class="floating-label mt-5">
+                <%= f.text_area :bio,
+                  autocomplete: "bio",
+                  placeholder: "Bio (optional)",
+                  class: "textarea textarea-lg input-primary w-full text-base-100 bg-base-200 rounded-lg" %>
+                  <span class="floating-label-text">Bio</span>
+              </label>
+
+              <div class="divider mb-4 mt-10">パスワード変更時のみ入力</div>
+
+              <label class="floating-label mt-5">
+                <%= f.password_field :password,
+                  autocomplete: "new-password",
+                  placeholder: "New Password",
+                  class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
+                  <span class="floating-label-text">New Password</span>
+              </label>
+
+              <label class="floating-label mt-5">
+                <%= f.password_field :password_confirmation,
+                  autocomplete: "new-password",
+                  placeholder: "Confirm New Password",
+                  class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
+                  <span class="floating-label-text">Confirm New Password</span>
+              </label>
+
+              <% if @minimum_password_length %>
+                <p class="mt-2 text-xs text-base-200">
+                <em><%= @minimum_password_length %> characters minimum</em>
+                </p>
+              <% end %>
+
+              <div class="divider mb-4 mt-10">パスワード</div>
+
+              <label class="floating-label mt-5">
+                <%= f.password_field :current_password,
+                  autocomplete: "current-password",
+                  placeholder: "Current Password (required)",
+                  class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
+                  <span class="floating-label-text">Current Password</span>
+              </label>
+              <p class="mt-1 text-xs text-base-200">
+              <em>※変更を確定するには現在のパスワードが必要です</em>
+              </p>
+
+              <div class="mt-8">
+                <%= f.submit "保存",
+                  class:"btn btn-secondary w-full text-base-200" %>
+              </div>
+            <% end %>
+
+            <div class="divider mb-4 mt-15">ユーザー削除</div>
+
+            <div class="flex flex-col items-center">
+              <%= button_to "アカウントを削除する", 
+                registration_path(@user), 
+                data: { confirm: "本当に削除しますか？", turbo_confirm: "本当に削除しますか？" }, 
+                method: :delete, 
+                class: "btn btn-error w-full" %>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="modal-action flex justify-center">
+        <form method="dialog">
+          <button class="btn btn-accent px-9">
+            <span class="material-symbols-outlined">
+              close
+            </span>
+          </button>
+        </form>
+      </div>
+    </div>
+
+    </dialog>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,23 +1,19 @@
-<div class="flex items-center justify-center min-h-screen px-6">
-  <div class="card bg-base-300 w-2xl h-2xl p-10 flex justify-center z-10">
+<div class="flex items-center justify-center">
+  <div class="card bg-base-300 w-2xl h-2xl p-5 flex justify-center z-10">
     <div>
-      <!-- ロゴ -->
-      <div class="flex justify-center mx-auto">
-        <%= link_to root_path do %>
-          <%= image_tag "mikaduki.png", width: "90" %>
-        <% end %>
-      </div>
 
       <!-- タイトルタブ -->
-      <div class="flex items-center justify-center mt-6 text-secondary">
-        <div role="tablist" class="tabs tabs-border">
-          <a role="tab" class="tab tab-active">アカウント編集</a>
-        </div>
+      <div class="flex items-center justify-center text-secondary">
+        <p class="text-xl">ユーザー編集</p>
       </div>
 
+      <!-- エラーメッセージ -->
+      <%= render "devise/shared/error_messages", resource: @user %>
+
       <!-- 編集フォーム -->
-      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), data: { turbo: false }, html: { method: :put, class: "w-full mt-6" }) do |f| %>
-        <%= render "devise/shared/error_messages", resource: resource %>
+      <%= form_for(@user, as: @user, url: registration_path(@user), html: { method: :put, class: "w-full mt-6" }) do |f| %>
+
+        <div class="divider mb-4">プロフィール</div>
 
         <label class="floating-label">
           <%= f.text_field :name,
@@ -25,7 +21,7 @@
             autocomplete: "name",
             placeholder: "User name",
             class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
-          <span class="floating-label-text">Name</span>
+            <span class="floating-label-text">Name</span>
         </label>
 
         <label class="floating-label mt-5">
@@ -33,21 +29,25 @@
             autocomplete: "email",
             placeholder: "Email address",
             class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
-          <span class="floating-label-text">Email</span>
+            <span class="floating-label-text">Email</span>
         </label>
 
-        <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-          <div class="mt-2 text-xs text-base-200">
-            Currently waiting confirmation for: <%= resource.unconfirmed_email %>
-          </div>
-        <% end %>
+        <label class="floating-label mt-5">
+          <%= f.text_area :bio,
+            autocomplete: "bio",
+            placeholder: "Bio (optional)",
+            class: "textarea textarea-lg input-primary w-full text-base-100 bg-base-200 rounded-lg" %>
+            <span class="floating-label-text">Bio</span>
+        </label>
+
+        <div class="divider mb-4 mt-10">パスワード変更時のみ入力</div>
 
         <label class="floating-label mt-5">
           <%= f.password_field :password,
             autocomplete: "new-password",
-            placeholder: "New Password (leave blank if no change)",
+            placeholder: "New Password",
             class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
-          <span class="floating-label-text">New Password</span>
+            <span class="floating-label-text">New Password</span>
         </label>
 
         <label class="floating-label mt-5">
@@ -55,44 +55,42 @@
             autocomplete: "new-password",
             placeholder: "Confirm New Password",
             class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
-          <span class="floating-label-text">Confirm New Password</span>
+            <span class="floating-label-text">Confirm New Password</span>
         </label>
 
         <% if @minimum_password_length %>
           <p class="mt-2 text-xs text-base-200">
-            <em><%= @minimum_password_length %> characters minimum</em>
+          <em><%= @minimum_password_length %> characters minimum</em>
           </p>
         <% end %>
+
+        <div class="divider mb-4 mt-10">パスワード</div>
 
         <label class="floating-label mt-5">
           <%= f.password_field :current_password,
             autocomplete: "current-password",
             placeholder: "Current Password (required)",
             class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
-          <span class="floating-label-text">Current Password</span>
+            <span class="floating-label-text">Current Password</span>
         </label>
         <p class="mt-1 text-xs text-base-200">
-          <em>※変更を確定するには現在のパスワードが必要です</em>
+        <em>※変更を確定するには現在のパスワードが必要です</em>
         </p>
 
-        <div class="mt-6">
-          <%= f.submit "更新",
+        <div class="mt-8">
+          <%= f.submit "保存",
             class:"btn btn-secondary w-full text-base-200" %>
         </div>
       <% end %>
 
-      <div class="divider text-base-200 my-6">アカウント削除</div>
-      
+      <div class="divider mb-4 mt-15">ユーザー削除</div>
+
       <div class="flex flex-col items-center">
         <%= button_to "アカウントを削除する", 
-          registration_path(resource_name), 
+          registration_path(@user), 
           data: { confirm: "本当に削除しますか？", turbo_confirm: "本当に削除しますか？" }, 
           method: :delete, 
           class: "btn btn-error w-full" %>
-        
-        <div class="mt-4">
-          <%= link_to "戻る", :back, class: "text-sm text-base-200 hover:underline" %>
-        </div>
       </div>
     </div>
   </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,43 +1,99 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class="flex items-center justify-center min-h-screen px-6">
+  <div class="card bg-base-300 w-2xl h-2xl p-10 flex justify-center z-10">
+    <div>
+      <!-- ロゴ -->
+      <div class="flex justify-center mx-auto">
+        <%= link_to root_path do %>
+          <%= image_tag "mikaduki.png", width: "90" %>
+        <% end %>
+      </div>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+      <!-- タイトルタブ -->
+      <div class="flex items-center justify-center mt-6 text-secondary">
+        <div role="tablist" class="tabs tabs-border">
+          <a role="tab" class="tab tab-active">アカウント編集</a>
+        </div>
+      </div>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      <!-- 編集フォーム -->
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), data: { turbo: false }, html: { method: :put, class: "w-full mt-6" }) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
+
+        <label class="floating-label">
+          <%= f.text_field :name,
+            autofocus: true,
+            autocomplete: "name",
+            placeholder: "User name",
+            class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
+          <span class="floating-label-text">Name</span>
+        </label>
+
+        <label class="floating-label mt-5">
+          <%= f.text_field :email,
+            autocomplete: "email",
+            placeholder: "Email address",
+            class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
+          <span class="floating-label-text">Email</span>
+        </label>
+
+        <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+          <div class="mt-2 text-xs text-base-200">
+            Currently waiting confirmation for: <%= resource.unconfirmed_email %>
+          </div>
+        <% end %>
+
+        <label class="floating-label mt-5">
+          <%= f.password_field :password,
+            autocomplete: "new-password",
+            placeholder: "New Password (leave blank if no change)",
+            class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
+          <span class="floating-label-text">New Password</span>
+        </label>
+
+        <label class="floating-label mt-5">
+          <%= f.password_field :password_confirmation,
+            autocomplete: "new-password",
+            placeholder: "Confirm New Password",
+            class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
+          <span class="floating-label-text">Confirm New Password</span>
+        </label>
+
+        <% if @minimum_password_length %>
+          <p class="mt-2 text-xs text-base-200">
+            <em><%= @minimum_password_length %> characters minimum</em>
+          </p>
+        <% end %>
+
+        <label class="floating-label mt-5">
+          <%= f.password_field :current_password,
+            autocomplete: "current-password",
+            placeholder: "Current Password (required)",
+            class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
+          <span class="floating-label-text">Current Password</span>
+        </label>
+        <p class="mt-1 text-xs text-base-200">
+          <em>※変更を確定するには現在のパスワードが必要です</em>
+        </p>
+
+        <div class="mt-6">
+          <%= f.submit "更新",
+            class:"btn btn-secondary w-full text-base-200" %>
+        </div>
+      <% end %>
+
+      <div class="divider text-base-200 my-6">アカウント削除</div>
+      
+      <div class="flex flex-col items-center">
+        <%= button_to "アカウントを削除する", 
+          registration_path(resource_name), 
+          data: { confirm: "本当に削除しますか？", turbo_confirm: "本当に削除しますか？" }, 
+          method: :delete, 
+          class: "btn btn-error w-full" %>
+        
+        <div class="mt-4">
+          <%= link_to "戻る", :back, class: "text-sm text-base-200 hover:underline" %>
+        </div>
+      </div>
+    </div>
   </div>
-
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
-
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
-    <% end %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
-<%= link_to "Back", :back %>
+</div>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,15 +1,22 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false">
-    <h2>
-      <%= I18n.t("errors.messages.not_saved",
-                 count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
-       %>
-    </h2>
-    <ul>
-      <% resource.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-    </ul>
+  <div role="alert" class="alert alert-error shadow-lg mb-6" data-turbo-cache="false">
+    <div>
+      <span class="material-symbols-outlined">
+        error
+      </span>
+      <div>
+        <h3 class="font-bold">
+          <%= I18n.t("errors.messages.not_saved",
+                     count: resource.errors.count,
+                     resource: resource.class.model_name.human.downcase)
+                   %>
+        </h3>
+        <ul class="mt-1 list-disc list-inside text-sm">
+          <% resource.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
   </div>
 <% end %>

--- a/app/views/static_pages/user_check.html.erb
+++ b/app/views/static_pages/user_check.html.erb
@@ -31,6 +31,7 @@
             
             <%= link_to "Log out", destroy_user_session_path, data: { turbo_method: :delete }, class: "btn btn-secondary w-full text-base-200" %>
             <%= link_to "ユーザー詳細", user_path(@user), class: "btn btn-outline btn-secondary w-full text-base-200 mt-4" %>
+            <%= link_to "Edit Profile", edit_user_registration_path, class: "btn btn-outline btn-secondary w-full text-base-200 mt-4" %>
           <% else %>
             <h1 class="text-2xl font-bold text-secondary mb-4">Welcome, Guest!</h1>
             <p class="text-base-100 mb-6">Please log in or sign up to continue.</p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -25,7 +25,7 @@
       </div>
 
       <div class="bg-primary flex justify-center w-full p-3 rounded-xl min-h-[100px] items-center">
-        <% if @user.bio.nil? %>
+        <% if @user.bio.blank? %>
           <p class="text-center">ここに自己紹介等が入ります</p>
         <% else %>
           <%= @user.bio %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -32,17 +32,15 @@
         <% end %>
       </div>
 
-      <% if current_user?(@user) %>
-        <div class="flex justify-between">
+      <div class="flex <%= current_user?(@user) ? 'justify-between' : 'justify-end' %>">
+        <% if current_user?(@user) %>
           <button class="btn btn-accent rounded-lg" onclick="edit_modal.showModal()">ユーザー編集</button>
-      <% else %>
-        <div class="flex justify-end">
-      <% end %>
+        <% end %>
         <button class="btn btn-neutral rounded-lg px-3">
           <%= image_tag 'x-logo.png', class: 'h-6 w-6' %>
         </button>
-        </div>
       </div>
+    </div>
 
     <% if current_user?(@user) %>
     <div class="bg-base-100 p-5 rounded-xl flex justify-center">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,6 +5,9 @@
   <!-- 内容表示部分 -->
   <div class="z-10 space-y-5 bg-base-300 border-t-1 border-x-1 border-base-200 relative p-8 text-center rounded-t-[4rem] xl:text-xl">
 
+    <!-- フラッシュメッセージ -->
+    <%= render 'flash' %>
+
     <div class=" text-center text-3xl">
       <%= @user.name %>
     </div>
@@ -22,15 +25,15 @@
       </div>
 
       <div class="bg-primary flex justify-center w-full p-3 rounded-xl min-h-[100px] items-center">
-        <% if @user.bio %>
-          <%= @user.bio %>
-        <% else %>
+        <% if @user.bio.nil? %>
           <p class="text-center">ここに自己紹介等が入ります</p>
+        <% else %>
+          <%= @user.bio %>
         <% end %>
       </div>
 
       <div class="flex justify-between">
-        <button class="btn btn-accent rounded-lg">ユーザー編集</button>
+        <button class="btn btn-accent rounded-lg" onclick="edit_modal.showModal()">ユーザー編集</button>
         <button class="btn btn-neutral rounded-lg px-3">
           <%= image_tag 'x-logo.png', class: 'h-6 w-6' %>
         </button>
@@ -93,3 +96,6 @@
   <!-- メニューバー -->
   <%= render 'menu_bar' %>
 </div>
+
+<!-- モーダル -->
+<%= render 'devise/registrations/edit_form_modal' %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -32,14 +32,19 @@
         <% end %>
       </div>
 
-      <div class="flex justify-between">
-        <button class="btn btn-accent rounded-lg" onclick="edit_modal.showModal()">ユーザー編集</button>
+      <% if current_user?(@user) %>
+        <div class="flex justify-between">
+          <button class="btn btn-accent rounded-lg" onclick="edit_modal.showModal()">ユーザー編集</button>
+      <% else %>
+        <div class="flex justify-end">
+      <% end %>
         <button class="btn btn-neutral rounded-lg px-3">
           <%= image_tag 'x-logo.png', class: 'h-6 w-6' %>
         </button>
+        </div>
       </div>
-    </div>
 
+    <% if current_user?(@user) %>
     <div class="bg-base-100 p-5 rounded-xl flex justify-center">
       <div class="text-center space-y-5">
         <p>認証して、LINEから確認する</p>
@@ -49,6 +54,7 @@
         </button>
         </div>
     </div>
+    <% end %>
 
     <!-- タスクの表示部分 -->
     <div class="tabs tabs-lift">
@@ -97,5 +103,7 @@
   <%= render 'menu_bar' %>
 </div>
 
-<!-- モーダル -->
-<%= render 'devise/registrations/edit_form_modal' %>
+<% if current_user?(@user) %>
+  <!-- モーダル -->
+  <%= render 'devise/registrations/edit_form_modal' %>
+<% end %>


### PR DESCRIPTION
<!-- github copilot レビューは日本語でお願いします -->
# 概要

<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->

ユーザー編集機能を追加しました。
また、errorメッセージやフラッシュメッセージのデザインを行いました。

# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイントです -->

- registrations/edit
  - デザインやフォームを調整しました。
  - 使用しないページではありますが、urlから飛ぶことはできるので、モーダルと同じデザインに統一しました。
- app/controllers/users/registrations_controller.rb
  - updateメソッドをオーバーライドしました
    - これにより、update失敗時にusers/showが表示され、@modal_openによって編集モーダルが開いた状態になります。
- app/views/static_pages/user_check.html.erb
  - registrations/editへのリンクを追加しました
- app/views/devise/registrations/_edit_form_modal.html.erb
  - ユーザー編集フォームをモーダルとしてパーシャル化しました。
  - これにより、users/showビューがコンパクトになります
- app/views/users/show.html.erb
  - フラッシュメッセージを表示するためのパーシャルを配置しました
  - また、現在のページのuserとcurrent userが一致する場合のみに編集ボタンやLINEログイン認証、編集モーダルを表示するようにしました
- app/views/devise/shared/_error_messages.html.erb
  - エラーメッセージのデザインを整えました
- app/views/application/_flash.html.erb
  - フラッシュメッセージパーシャルを追加しました
- app/helpers/application_helper.rb
  - current_user?メソッドを定義しました

## スクリーンショット

users/show
![Screenshot 2025-04-12 215901](https://github.com/user-attachments/assets/1f344fb3-c25c-41a2-82cd-ad7f07cd6ea1)
users/show内のedit_form_modal
![Screenshot 2025-04-12 215919](https://github.com/user-attachments/assets/83599083-1fcb-4060-8783-2c51cc29f6e8)
registrations/edit
![Screenshot 2025-04-12 230812](https://github.com/user-attachments/assets/2a072d79-3935-4cde-8e52-2a6e81a37579)

# 影響範囲・懸念点


<!-- レビュアーに見てほしい点、影響しそうな機能 -->

updatemメソッドをオーバーライドしたことによるセキュリティ面の弱体化の点

# おこなった動作確認

<!-- おこなった動作確認を箇条書きで。大きなUI変更は iOS Safari / Android Chrome での確認もすること -->
- registrations/edit
  - 失敗時と成功時にusers/showに移行することを確認
  - 成功時に内容が保存されていることを確認
- users/show
  - モーダルが表示されることを確認
  - 失敗時と成功時に使用通り挙動するか確認



<!-- github copilot レビューは日本語でお願いします -->
