### PR TITLE
task詳細画面を実装しました closes #21

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -7,7 +7,14 @@ class TasksController < ApplicationController
   end
 
   # GET /tasks/1 or /tasks/1.json
-  def show; end
+  def show
+    if @task.milestone&.is_public || @task.milestone&.user&.id == current_user.id
+      # taskに関連するmilestoneが公開されているか、またはmilestoneのユーザーが現在のユーザーと同じ場合
+    else
+      flash[:alert] = "このタスクは非公開です"
+      redirect_to user_check_path
+    end
+  end
 
   # GET /tasks/new
   def new

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,6 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import ShowModalController from "./show_modal_controller"
+application.register("show-modal", ShowModalController)

--- a/app/javascript/controllers/show_modal_controller.js
+++ b/app/javascript/controllers/show_modal_controller.js
@@ -2,6 +2,12 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="show-modal"
 export default class extends Controller {
+  static targets = ["task_modal"]
+
   connect() {
+    console.log("ShowModalController connected")
+    this.task_modalTarget.showModal();
   }
+
+
 }

--- a/app/javascript/controllers/show_modal_controller.js
+++ b/app/javascript/controllers/show_modal_controller.js
@@ -5,8 +5,6 @@ export default class extends Controller {
   static targets = ["task_modal"]
 
   connect() {
-    console.log("ShowModalController connected")
-    this.task_modalTarget.showModal();
   }
 
 

--- a/app/javascript/controllers/show_modal_controller.js
+++ b/app/javascript/controllers/show_modal_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="show-modal"
+export default class extends Controller {
+  connect() {
+  }
+}

--- a/app/views/static_pages/_auth_buttons.html.erb
+++ b/app/views/static_pages/_auth_buttons.html.erb
@@ -1,12 +1,12 @@
 <div class="relative z-10">
   <div class="flex justify-center items-center mb-4">
-    <%= link_to "新規登録", new_user_registration_path, class: "btn btn-neutral text-accent w-[170px] h-[50px]" %>
-    <button class="btn btn-secondary ml-4 w-[170px] h-[50px]">
+    <%= link_to "新規登録", new_user_registration_path, class: "btn btn-neutral text-accent w-42 h-12" %>
+    <button class="btn btn-secondary ml-4 w-42 h-12">
       ログインせず<br>
       使ってみる
     </button>
   </div>
   <div class="flex justify-center">
-    <%= link_to "ログイン", new_user_session_path, class: "btn btn-accent mb-15 w-[170px] h-[50px]" %>
+    <%= link_to "ログイン", new_user_session_path, class: "btn btn-accent mb-15 w-42 h-12" %>
   </div>
 </div>

--- a/app/views/static_pages/user_check.html.erb
+++ b/app/views/static_pages/user_check.html.erb
@@ -117,7 +117,11 @@
                       <p class="text-sm text-base-100">Progress:</p>
                       <p class="text-lg text-primary"><%= task.progress %></p>
                     </div>
+
+                    <%= link_to "show", task_path(task), class: "btn btn-secondary w-full text-base-200 mt-4", data: { turbo_frame: "tasks_show_modal"} %>
+
                   </div>
+
                 <% end %>
               </div>
             </div>
@@ -143,3 +147,4 @@
 </div>
 <%= render "milestones/milestone_new_form", milestone: @milestone %>
 <%= render "tasks/tasks_new_form", task: @task, milestones: @milestones %>
+<%= turbo_frame_tag "tasks_show_modal" %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,10 +1,127 @@
-<p style="color: green"><%= notice %></p>
+<%= turbo_frame_tag "tasks_show_modal" do %>
+  <div data-controller="show-modal">
+    <dialog data-show-modal-target="task_modal" id="tasks_show_modal" class="modal" <%= @task_new_modal_open ? 'open' : ' ' %> >
+      <div class="modal-box">
+        <p class="text-center pb-4">ESC or 下の(X)を押すと閉じます</p>
+        <div class="flex w-full items-center justify-center">
+          <div class="card z-10 flex h-2xl w-full justify-center bg-base-300 p-5 text-center md:w-2xl">
+            <div>
 
-<%= render @task %>
+              <!-- エラーメッセージ -->
+              <%= render "error_messages", resource: @task%>
 
-<div>
-  <%= link_to "Edit this task", edit_task_path(@task) %> |
-  <%= link_to "Back to tasks", tasks_path %>
+              <!-- タスク詳細表示 -->
+              <div class="space-y-5">
+                <div class="flex items-center justify-center text-secondary">
+                  <p class="text-xl">詳細</p>
+                </div>
 
-  <%= button_to "Destroy this task", @task, method: :delete %>
-</div>
+                <!-- マイルストーン -->
+                <% if @task.milestone.present? %>
+                  <div class="flex items-center justify-center text-xl">
+                    <div class="mr-2">
+                      <%= render "stars_icon", { width: 35, height: 35, color: @task.milestone.color } %>
+                    </div>
+                    <%= @task.milestone.title %>
+                  </div>
+                <% else %>
+                  <div class="flex items-center justify-center text-xl">
+                    <div class="mr-2">
+                      <%= render "stars_icon", { width: 35, height: 35 } %>
+                    </div>
+                    星座未設定
+                  </div>
+                <% end %>
+
+                <!-- タイトル -->
+                <div class="flex w-full items-center justify-center">
+                  <div class="card w-full text-neutral">
+                      <p class="card-title h-5 pl-2 text-sm text-primary">Title</p>
+                      <div class="flex w-full items-center justify-center rounded-xl bg-primary p-3">
+                        <%= @task.title %>
+                      </div>
+                  </div>
+                </div>
+
+
+                <!-- 期間 -->
+                <% if @task.start_date.present? || @task.end_date.present? %>
+                    <div class="flex w-full justify-between px-5 text-neutral">
+                      <div class="card flex h-full w-2/5 flex-col justify-center bg-primary p-2">
+                        <div>
+                          <%= @task.start_date&.year %>年
+                        </div>
+                        <div class="w-full font-bold md:text-2xl">
+                          <%= @task.start_date&.mon %>月
+                          <%= @task.start_date&.mday %>日
+                          (<%= day_of_week(@task.start_date) %>)
+                        </div>
+                      </div>
+                      <div class="flex w-1/5 items-center justify-center">
+                        <p class="w-full text-5xl text-primary">~</p>
+                      </div>
+                      <div class="card flex h-full w-2/5 flex-col justify-center bg-primary p-2">
+                        <%= @task.end_date&.year %>年<br>
+                        <div class="w-full font-bold md:text-2xl">
+                          <%= @task.end_date&.mon %>月
+                          <%= @task.end_date&.mday %>日
+                          (<%= day_of_week(@task.end_date) %>)
+                        </div>
+                      </div>
+                    </div>
+                <% else %>
+                  <div class="flex w-full justify-center">
+                    <div class="card w-full bg-primary p-10 text-neutral">
+                      日付は設定されていません
+                    </div>
+                  </div>
+                <% end %>
+
+                <!-- 説明 -->
+                <div class="flex w-full items-center justify-center">
+                  <div class="card w-full text-neutral">
+                      <p class="card-title h-5 pl-2 text-sm text-primary">Description</p>
+                      <div class="flex min-h-24 w-full items-center justify-center rounded-xl bg-primary p-3">
+                          <%= @task.description.present? ? @task.description : "説明はありません" %>
+                      </div>
+                  </div>
+                </div>
+
+                <!-- 進捗状況 -->
+                <div class="flex w-full items-center justify-center">
+                  <div class="card w-full text-neutral">
+                      <p class="card-title h-5 pl-2 text-sm text-primary">Progress</p>
+                      <div class="flex w-full items-center justify-center rounded-xl bg-primary p-3">
+                        <%= @task.progress.humanize %>
+                      </div>
+                  </div>
+                </div>
+
+                <!-- アクションボタン -->
+                <div class="flex h-12 w-full mt-10 justify-center text-neutral">
+                  <div class="btn btn-error mr-5 h-12 w-25 md:w-42">
+                    削除
+                  </div>
+                  <div class="btn btn-accent h-12 w-25 md:w-42">
+                    編集
+                  </div>
+                </div>
+              </div>
+
+              </div>
+          </div>
+        </div>
+        <div class="modal-action flex justify-center">
+          <form method="dialog">
+            <button class="btn btn-accent px-9">
+              <span class="material-symbols-outlined">
+                close
+              </span>
+            </button>
+          </form>
+        </div>
+      </div>
+
+    </dialog>
+  </div>
+<% end %>


### PR DESCRIPTION
<!-- github copilot レビューは日本語でお願いします -->
# 概要

<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->

タスク詳細表示を実装しました。
モーダルでの実装にあたり、stimulusとturboFrameを用いています


# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイントです -->

- app/javascript/controllers/show_modal_controller.js
  - task/showがturboframeでレンダリングされた際に、showビュー内にある要素にdata-controllerを記載することで、レンダリング時に自動的にモーダルが開くような形で実装しています
  - そのため、connect時にshowmodalを実行しっています

- app/views/static_pages/user_check.html.erb
  - task_path(task)によって、task/showへのリンクを配置しました
    - data: turbo_frame: task_show_modalによって<%= turbo_frame_tag "tasks_show_modal" %>を対象としたリンクにしています
  - <%= turbo_frame_tag "tasks_show_modal" %>を配置

- app/views/tasks/show.html.erb
  - モーダルとして実装しました
  - 以下の部分で、前述のような指定を行っています
```
 <%= turbo_frame_tag "tasks_show_modal" do %>
  <div data-controller="show-modal">
    <dialog data-show-modal-target="task_modal" id="tasks_show_modal" class="modal" <%= @task_new_modal_open ? 'open' : ' ' %> >
```

- app/views/static_pages/_auth_buttons.html.erb
  - サイズの指定をtailwindによる数値の指定にしました

- app/controllers/tasks_controller.rb
  - taskに関連するmilestoneが公開されているか、またはmilestoneのユーザーが現在のユーザーと同じ場合のみ表示するようにしました
![Screenshot 2025-04-16 174528](https://github.com/user-attachments/assets/41bf3f4c-29ba-45d1-ba4f-ac036a0d5fca)



<!-- github copilot レビューは日本語でお願いします -->
