### PR TITLE
fix:turbostreamのターゲットが２つ配置される状態だったので、とりあえずinprogressとnotstartedタブを消しました

### DIFF
--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -17,7 +17,7 @@
 
     <!-- 表示部分 -->
     <div class="flex w-full items-center justify-center mb-10">
-      <div class="tabs tabs-lift tabs-sm w-xl">
+      <div class="tabs tabs-lift w-xl">
         <!-- 未完了のタスク -->
         <input type="radio" name="my_tabs" class="tab w-1/6" aria-label="未完了" checked="checked"/>
         <div class="tab-content border-base-300 bg-base-100 p-3">
@@ -37,20 +37,6 @@
 
         </div>
 
-        <!-- not_start -->
-        <input type="radio" name="my_tabs" class="tab w-1/6" aria-label="未着手" />
-        <div class="tab-content border-base-300 bg-base-100 p-3">
-          <!-- タスク -->
-          <%= render "tasks", tasks: @not_started_tasks %>
-        </div>
-
-        <!-- in_progress -->
-        <input type="radio" name="my_tabs" class="tab w-1/6" aria-label="進行中" />
-        <div class="tab-content border-base-300 bg-base-100 p-3">
-          <!-- タスク -->
-          <%= render "tasks", tasks: @in_progress_tasks %>
-        </div>
-
         <!-- completed -->
         <input type="radio" name="my_tabs" class="tab w-1/6" aria-label="完了" />
         <div class="tab-content border-base-300 bg-base-100 p-3">
@@ -63,8 +49,6 @@
         <div class="tab-content border-base-300 bg-base-100 p-3">
           <!-- タスク -->
           <%= render "tasks", tasks: @tasks %>
-
-
         </div>
 
       </div>


### PR DESCRIPTION
<!-- github copilot レビューは日本語でお願いします -->
# 概要

<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->

task/indexのタブを修正しました。

# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイントです -->

- turbostreamで置換している関係で、idが被っていると、最初に登場した要素を対象に置換する。　
- タブで同じidの要素を何度か表示することになってしまっていた
- 将来的に、ransack等で絞ることで実現しようかと思います


