### PR TITLE
task編集機能を追加しました closes #26

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -14,7 +14,7 @@ class TasksController < ApplicationController
     @not_completed_tasks = @tasks.where.not(progress: :completed)
   end
 
-  # GET /tasks/1 or /tasks/1.json
+  # GET /tasks/1
   def show
     if @task.milestone&.is_public || current_user?(@task&.user)
       # taskに関連するmilestoneが公開されているか、またはmilestoneのユーザーが現在のユーザーと同じ場合
@@ -37,7 +37,7 @@ class TasksController < ApplicationController
     @milestones = user.milestones
   end
 
-  # POST /tasks or /tasks.json
+  # POST /tasks
   def create
     @task = Task.new(task_params)
 
@@ -49,9 +49,10 @@ class TasksController < ApplicationController
       redirect_to tasks_path
     else
       # タスクの作成に失敗した場合、モーダルを開いた状態でタスク一覧を表示
-      # indexをrenderすることで、@taskがnilにならないようにする
+      # indexをrenderすることで、@taskに編集内容が反映される
       # indexに渡すインスタンス変数は、@taskを除いてすべて同じ
       @task_new_modal_open = true
+      @title = "タスク一覧"
       @user = current_user
       @milestones = @user.milestones
       @tasks = @user.tasks.includes(:milestone).order(created_at: :desc)
@@ -65,22 +66,16 @@ class TasksController < ApplicationController
 
   # turbo_streamでモーダルを更新している
   def update
+    user = current_user
+    @milestones = user.milestones
+
     if @task.update(task_params)
       # タスクの更新に成功した場合、タスク詳細を表示
       @task_show_modal_open = true
-      @user = current_user
-      @milestones = @user.milestones
-
       flash.now[:notice] = "タスクを更新しました"
     else
       # タスクの更新に失敗した場合、editモーダルを開いた状態でタスク一覧を表示
       @task_edit_modal_open = true
-      @user = current_user
-      @milestones = @user.milestones
-      @tasks = @user.tasks.includes(:milestone).order(created_at: :desc)
-      @completed_tasks = @tasks.where(progress: :completed)
-      @not_completed_tasks = @tasks.where.not(progress: :completed)
-
       flash.now[:alert] = "タスクの更新に失敗しました"
     end
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,6 +3,7 @@ class Task < ApplicationRecord
   belongs_to :user
 
   validates :title, presence: true
+  validates :progress, presence: true
 
   enum progress: [:not_started, :in_progress, :completed]
 end

--- a/app/views/application/_flash.html.erb
+++ b/app/views/application/_flash.html.erb
@@ -1,3 +1,4 @@
+<div id="flash">
 <% if flash[:notice] %>
   <div role="alert" class="alert alert-success">
     <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 shrink-0 stroke-current" fill="none" viewBox="0 0 24 24">
@@ -45,3 +46,4 @@
     </button>
   </div>
 <% end %>
+</div>

--- a/app/views/milestones/show.html.erb
+++ b/app/views/milestones/show.html.erb
@@ -28,10 +28,8 @@
             <div>
               <%= @milestone.start_date&.year %>年
             </div>
-            <div class="w-full text-2xl">
-              <%= @milestone.start_date&.mon %>月
-              <%= @milestone.start_date&.mday %>日
-              (<%= day_of_week(@milestone.start_date) %>)
+            <div class="w-full text-xl">
+              <%= to_short_date(@milestone.start_date) %>
             </div>
           </div>
           <div class="flex w-1/5 items-center justify-center">
@@ -39,10 +37,8 @@
           </div>
           <div class="card flex h-full w-2/5 flex-col justify-center bg-primary p-2">
             <%= @milestone.end_date&.year %>年<br>
-            <div class="w-full text-2xl">
-              <%= @milestone.end_date&.mon %>月
-              <%= @milestone.end_date&.mday %>日
-              (<%= day_of_week(@milestone.end_date) %>)
+            <div class="w-full text-xl">
+              <%= to_short_date(@milestone.end_date) %>
             </div>
           </div>
         </div>
@@ -105,10 +101,10 @@
 
     <% if current_user?(@milestone.user) %>
       <div class="flex h-12 w-full justify-center text-neutral">
-        <div class="btn btn-error mr-5 h-12 w-42">
+        <div class="btn btn-error mr-5 h-12 w-25 md:w-42">
           削除
         </div>
-        <button class="btn btn-accent h-12 w-42" onclick="milestone_edit_modal.showModal()">
+        <button class="btn btn-accent h-12 w-25 md:w-42" onclick="milestone_edit_modal.showModal()">
           編集
         </button>
       </div>

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -1,0 +1,37 @@
+<div id="tasks_update_replace_task_<%=task.id%>" class="card mb-4 w-full p-4 bg-base-300/40 shadow-xl/10">
+
+  <div class="flex w-full items-center text-left">
+    <%= link_to task_path(task), class: "w-full p-1 rounded-xl hover:bg-base-300/30", data: { turbo_frame: "tasks_show_modal"} do %>
+      <!-- タイトル, 日付, マーク -->
+      <div class="flex w-full">
+        <div class="flex items-center">
+          <%= render "star_icon", color: task.milestone&.color %>
+        </div>
+
+        <div class="ml-2 w-7/10">
+          <p class="text-lg"><%= task.title %></p>
+
+          <p class="text-sm"><%= to_short_date(task.start_date) %> ~ <%= to_short_date(task.end_date) %></p>
+        </div>
+      </div>
+
+      <!-- 詳細 -->
+      <div class="text-left mt-1">
+        <% if task.description.present? %>
+          <p class="text-lg"><%= task.description.truncate(20) %></p>
+        <% else %>
+          <p class="text-lg">詳細はありません</p>
+        <% end %>
+      </div>
+
+
+    <% end %>
+
+    <% if current_user?(task.user) %>
+      <!-- progressボタン -->
+      <%= render "progress_button", task: task %>
+    <% end %>
+  </div>
+
+</div>
+

--- a/app/views/tasks/_task_edit_form.html.erb
+++ b/app/views/tasks/_task_edit_form.html.erb
@@ -1,0 +1,101 @@
+<%= turbo_frame_tag "task_edit_modal" do %>
+  <dialog class="modal" <%= task_edit_modal_open ? 'open' : ' ' %> >
+
+    <!-- tasks/edit_modal.html.erbも同様に編集する -->
+    <!-- まずはturbo_frame_tagを使ってtasks/editでモーダルの部分を表示 -->
+    <!-- tasks#updateでturbo_stremasを使って、モーダルの部分を_tasks_editファイルに置換しています -->
+
+    <!-- ここから貼り付け from "_tasks_edit_form.html" -->
+    <div id="turbo_update_false_target" class="modal-box max-h-[90vh]">
+      <p class="pb-4 text-center">ESC or 下の(X)を押すと閉じます</p>
+      <div class="flex w-full items-center justify-center">
+        <div class="card bg-base-300 w-full h-2xl p-3 flex justify-center z-10">
+          <div>
+
+            <!-- タイトルタブ -->
+            <div class="flex items-center justify-center text-secondary">
+              <p class="text-xl">タスク編集</p>
+            </div>
+
+            <!-- エラーメッセージ -->
+            <%= render "error_messages", resource: task%>
+
+            <!-- 編集フォーム -->
+            <%= form_with(model: task, class: "w-full mt-6 p-2", data: { turbo_stream: true }) do |f| %>
+
+              <label class="floating-label">
+                <%= f.collection_select :milestone_id, milestones, :id, :title,
+                      { include_blank: "Select Milestone" },
+                      class: "select select-lg select-primary w-full text-base-100 bg-base-200" %>
+                      <span class="floating-label-text">Milestone</span>
+              </label>
+
+              <label class="floating-label mt-10">
+                <%= f.text_field :title,
+                      autofocus: true,
+                      autocomplete: "title",
+                      placeholder: "Title",
+                      class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
+                      <span class="floating-label-text">Title</span>
+              </label>
+
+              <div class="flex justify-center">
+                <label class="mt-5 w-50">
+                  <span class="text-base-200 text-sm">Start Date</span>
+                  <%= f.date_field :start_date,
+                        autocomplete: "Start Date",
+                        placeholder: "Start Date",
+                        class: "text-base-200 bg-base-100 rounded-full p-3 w-full" %>
+                </label>
+              </div>
+
+
+              <div class="flex justify-center">
+                <label class="mt-5 w-50">
+                  <span class="text-base-200 text-sm">End Date</span>
+                  <%= f.date_field :end_date,
+                        autocomplete: "End Date",
+                        placeholder: "End Date",
+                        class: "text-base-200 bg-base-100 rounded-full p-3 w-full" %>
+                </label>
+              </div>
+
+              <label class="floating-label mt-5">
+                <%= f.text_area :description,
+                      autocomplete: "description",
+                      placeholder: "Description",
+                      class: "textarea textarea-lg input-primary w-full text-base-100 bg-base-200 rounded-lg" %>
+                      <span class="floating-label-text">Description</span>
+              </label>
+
+              <label class="floating-label mt-5">
+                <%= f.collection_select :progress, Task.progresses.keys, :to_s, :humanize,
+                      { include_blank: "Select Progress" },
+                      class: "select select-lg select-primary w-full text-base-100 bg-base-200" %>
+                      <span class="floating-label-text">Progress</span>
+              </label>
+
+
+              <div class="mt-10">
+                <%= f.submit "保存", class:"btn btn-secondary w-full text-base-200" %>
+              </div>
+            <% end %>
+
+          </div>
+        </div>
+      </div>
+      <div class="modal-action flex justify-center">
+        <form method="dialog">
+          <button class="btn btn-accent px-9">
+            <span class="material-symbols-outlined">
+              close
+            </span>
+          </button>
+        </form>
+      </div>
+    </div>
+    <!-- ここまで貼り付け from "_tasks_edit_form.html" -->
+
+  </dialog>
+<% end %>
+

--- a/app/views/tasks/_tasks.html.erb
+++ b/app/views/tasks/_tasks.html.erb
@@ -1,42 +1,7 @@
 <!-- 星座 -->
 <div class="mx-auto">
   <% tasks.each do |task| %>
-    <div class="card mb-4 w-full p-4 bg-base-300/40 shadow-xl/10">
-
-      <div class="flex w-full items-center text-left">
-        <%= link_to task_path(task), class: "w-full p-1 rounded-xl hover:bg-base-300/30", data: { turbo_frame: "tasks_show_modal"} do %>
-          <!-- タイトル, 日付, マーク -->
-          <div class="flex w-full">
-              <div class="flex items-center">
-                <%= render "star_icon", color: task.milestone&.color %>
-              </div>
-
-            <div class="ml-2 w-7/10">
-              <p class="text-lg"><%= task.title %></p>
-
-              <p class="text-sm"><%= to_short_date(task.start_date) %> ~ <%= to_short_date(task.end_date) %></p>
-            </div>
-          </div>
-
-          <!-- 詳細 -->
-          <div class="text-left mt-1">
-            <% if task.description.present? %>
-              <p class="text-lg"><%= task.description.truncate(20) %></p>
-            <% else %>
-              <p class="text-lg">詳細はありません</p>
-            <% end %>
-          </div>
-
-
-        <% end %>
-
-        <% if current_user?(task.user) %>
-          <!-- progressボタン -->
-          <%= render "progress_button", task: task %>
-        <% end %>
-      </div>
-
-    </div>
+    <%= render "task", task: task %>
   <% end %>
 </div>
 

--- a/app/views/tasks/_tasks_show_modal.html.erb
+++ b/app/views/tasks/_tasks_show_modal.html.erb
@@ -1,14 +1,11 @@
-<!-- stimulusを使用して、connect時にモーダルを開く -->
 <%= turbo_frame_tag "tasks_show_modal" do %>
-  <div data-controller="show-modal">
-    <div data-show-modal-target="modal_top">
-      <dialog data-show-modal-target="task_modal" id="tasks_show_modal" class="modal" <%= @task_show_modal_open ? 'open' : ' ' %> >
+      <dialog id="tasks_show_modal" class="modal" <%= task_show_modal_open ? 'open' : ' ' %> >
 
-        <!-- _tasks_show_modal.html.erbも同様に編集する -->
+        <!-- tasks/show_modal.html.erbを先に編集する -->
         <!-- まずはturbo_frame_tagを使ってtasks/showでモーダルの部分を表示 -->
-        <!-- tasks#updateでturbo_stremasを使って、モーダルの部分を_tasks_showファイルに置換しています -->
+        <!-- tasks#updateでturbo_stremasを使って、モーダルの部分をこのファイルに更新しています -->
 
-        <!-- ここから貼り付け to "_tasks_show.html" -->
+        <!-- ここから貼り付け from "tasks/show.html" -->
 
         <div class="modal-box max-h-[90vh]">
           <p class="text-center pb-4">ESC or 画面外を押すと閉じます</p>
@@ -131,12 +128,10 @@
         </div>
         </div>
 
-        <!-- ここまで貼り付け to "_tasks_show.html" -->
+        <!-- ここまで貼り付け from "tasks/show.html" -->
 
         <form method="dialog" class="modal-backdrop">
           <button>close</button>
         </form>
       </dialog>
-    </div>
-  </div>
 <% end %>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,12 +1,106 @@
-<% content_for :title, "Editing task" %>
+<!-- stimulusを使用して、connect時にモーダルを開く -->
+<%= turbo_frame_tag "task_edit_modal" do %>
+  <div data-controller="show-modal">
+    <div data-show-modal-target="modal_top">
+      <dialog data-show-modal-target="task_modal" class="modal" <%= @task_new_modal_open ? 'open' : ' ' %> >
 
-<h1>Editing task</h1>
 
-<%= render "form", task: @task %>
+        <!-- _tasks_edit_modal.html.erbも同様に編集する -->
+        <!-- まずはturbo_frame_tagを使ってtasks/editでモーダルの部分を表示 -->
+        <!-- tasks#updateでturbo_stremasを使って、モーダルの部分を_tasks_editファイルに置換しています -->
 
-<br>
+        <!-- ここからコピー to "_tasks_edit_form.html" -->
+        <div class="modal-box max-h-[90vh]">
+          <p class="pb-4 text-center">ESC or 下の(X)を押すと閉じます</p>
+          <div class="flex w-full items-center justify-center">
+            <div class="card bg-base-300 w-full h-2xl p-3 flex justify-center z-10">
+              <div>
 
-<div>
-  <%= link_to "Show this task", @task %> |
-  <%= link_to "Back to tasks", tasks_path %>
-</div>
+                <!-- タイトルタブ -->
+                <div class="flex items-center justify-center text-secondary">
+                  <p class="text-xl">タスク編集</p>
+                </div>
+
+                <!-- エラーメッセージ -->
+                <%= render "error_messages", resource: @task%>
+
+                <!-- 編集フォーム -->
+                <%= form_with(model: @task, class: "w-full mt-6 p-2", data: { turbo_stream: true }) do |f| %>
+
+                  <label class="floating-label">
+                    <%= f.collection_select :milestone_id, @milestones, :id, :title,
+                      { include_blank: "Select Milestone" },
+                      class: "select select-lg select-primary w-full text-base-100 bg-base-200" %>
+                    <span class="floating-label-text">Milestone</span>
+                  </label>
+
+                  <label class="floating-label mt-10">
+                    <%= f.text_field :title,
+                      autofocus: true,
+                      autocomplete: "title",
+                      placeholder: "Title",
+                      class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
+                    <span class="floating-label-text">Title</span>
+                  </label>
+
+                  <div class="flex justify-center">
+                    <label class="mt-5 w-50">
+                      <span class="text-base-200 text-sm">Start Date</span>
+                      <%= f.date_field :start_date,
+                        autocomplete: "Start Date",
+                        placeholder: "Start Date",
+                        class: "text-base-200 bg-base-100 rounded-full p-3 w-full" %>
+                  </label>
+                  </div>
+
+
+                  <div class="flex justify-center">
+                    <label class="mt-5 w-50">
+                      <span class="text-base-200 text-sm">End Date</span>
+                      <%= f.date_field :end_date,
+                        autocomplete: "End Date",
+                        placeholder: "End Date",
+                        class: "text-base-200 bg-base-100 rounded-full p-3 w-full" %>
+                  </label>
+                  </div>
+
+                  <label class="floating-label mt-5">
+                    <%= f.text_area :description,
+                      autocomplete: "description",
+                      placeholder: "Description",
+                      class: "textarea textarea-lg input-primary w-full text-base-100 bg-base-200 rounded-lg" %>
+                    <span class="floating-label-text">Description</span>
+                  </label>
+
+                  <label class="floating-label mt-5">
+                    <%= f.collection_select :progress, Task.progresses.keys, :to_s, :humanize,
+                      { include_blank: "Select Progress" },
+                      class: "select select-lg select-primary w-full text-base-100 bg-base-200" %>
+                    <span class="floating-label-text">Progress</span>
+                  </label>
+
+
+                  <div class="mt-10">
+                    <%= f.submit "保存", class:"btn btn-secondary w-full text-base-200" %>
+                  </div>
+                <% end %>
+
+              </div>
+            </div>
+          </div>
+          <div class="modal-action flex justify-center">
+            <form method="dialog">
+              <button class="btn btn-accent px-9">
+                <span class="material-symbols-outlined">
+                  close
+                </span>
+              </button>
+            </form>
+          </div>
+        </div>
+        <!-- ここまでコピー to "_tasks_edit_form.html" -->
+
+      </dialog>
+    </div>
+  </div>
+<% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -52,5 +52,7 @@
   <div class="mt-10" >
     <%= render "menu_bar" %>
   </div>
+  <%= turbo_frame_tag "task_edit_modal" %>
   <%= turbo_frame_tag "tasks_show_modal" %>
   <%= render "tasks/tasks_new_form", task: @task, milestones: @milestones %>
+

--- a/app/views/tasks/update.turbo_stream.erb
+++ b/app/views/tasks/update.turbo_stream.erb
@@ -1,0 +1,21 @@
+  <!-- update成功時も失敗時も呼ばれる -->
+  <!-- 成功時は@task_edit_modal_openを渡していないのでedit_modalは閉じた状態でreplaceされる -->
+  <!-- 成功時は@task_show_modal_open: trueを渡しているのでshow_modalは開いた状態でreplaceされる -->
+  <!-- 失敗時は@task_edit_modal_open: trueを渡しているのでedit_modalは開いた状態でreplaceされる -->
+  <!-- 失敗時は@task_show_modal_open: 渡していないのでshow_modalは閉じた状態でreplaceされる -->
+
+  <%= turbo_stream.replace "task_edit_modal" do %>
+    <%= render "task_edit_form", task: @task, milestones: @milestones, task_edit_modal_open: @task_edit_modal_open %>
+  <% end %>
+
+  <%= turbo_stream.replace "flash" do %>
+    <%= render "flash" %>
+  <% end %>
+
+  <%= turbo_stream.replace "tasks_show_modal" do %>
+    <%= render "tasks_show_modal", task: @task, task_show_modal_open: @task_show_modal_open %>
+  <% end %>
+
+  <%= turbo_stream.replace "tasks_update_replace_task_#{@task.id}" do %>
+    <%= render "task", task: @task %>
+  <% end %>


### PR DESCRIPTION
<!-- github copilot レビューは日本語でお願いします -->
# 概要

<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->

タスク編集機能を追加しました
  - 編集画面表示時はturbo_frameでtask_edit_modal要素を置換します。
  - update時は、task_edit_modal、task_show_modal、flash、編集対象の要素の4つを対象にturbo_streamで置換します。

# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイントです -->


- app/controllers/tasks_controller.rb
  - editメソッドupdateメソッドを実装
  - indexメソッドとcreateメソッドの不要なインスタンス変数を削除
- app/models/task.rb
  - progressにpresence: trueバリデーションを追加
- app/views/tasks/_task.html.erb
  - task表示用パーシャル
  - tasks#update後にturbo_streamで置換
- app/views/tasks/_task_edit_form.html.erb
  - tasks#update実行後、turbo_streamによって置換する要素
  - 内容はtasks/editとほぼ同様
- app/views/tasks/_tasks.html.erb
  - each後のtask表示部分をパーシャルに切り出し
- app/views/tasks/_tasks_show_modal.html.erb
  - tasks#update実行後、turbo_streamによって置換する要素
  - 内容はtasks/showとほぼ同様
- app/views/tasks/edit.html.erb
  - 編集モーダル要素を追加しました
  - turbo_frame_tag "task_edit_modal"で囲っており、レンダリング時にtasks/indexにあるturbo_frame_tag "task_edit_modalと置換
- app/views/tasks/index.html.erb
  - 編集モーダル置換対象であるturbo_frame_tag "task_edit_modal"を追加
- app/views/tasks/show.html.erb
  - 日付の表示を変更
  - 編集へのリンクを追加
- app/views/tasks/update.turbo_stream.erb
  - update後に置換されるturbo_streamの要素
  - 成功時はedit_modalは閉じた状態, show_modalは開いた状態でreplaceされる
  - 失敗時はedit_modalは開いた状態, show_modalは閉じた状態でreplaceされる
  - 編集対象の要素の内容をreplasceする

- app/views/application/_flash.html.erb
  - flashが一度置換されたあと、置換できなくなる問題を修正

- branch fix/milestone_show_date_to_short
    - app/views/milestones/show.html.erb
        - 日付の表示を調整
        - スマホ表示時に、削除編集ボタンがはみ出る問題を修正


## スクリーンショット

<!-- Command + Shift + Control + 4 でスクリーンショットして Command + V でここに貼り付けるのが楽。以下のテーブルは必要に応じて使ってください -->

![image](https://github.com/user-attachments/assets/2d880bde-4006-4279-9a71-837732293219)
![image](https://github.com/user-attachments/assets/dd65e786-6071-430a-aebd-380597d96e29)


<!-- github copilot レビューは日本語でお願いします -->

