### PR TITLE
milestones詳細画面に、それに属するtaskを表示しました closes #28

### DIFF
--- a/app/controllers/milestones_controller.rb
+++ b/app/controllers/milestones_controller.rb
@@ -21,7 +21,6 @@ class MilestonesController < ApplicationController
              end
 
     if @milestone.is_public || current_user?(@milestone.user)
-      @from_milestone_show = true
       @milestone_tasks = @milestone.tasks
       @task = Task.new
     else

--- a/app/controllers/milestones_controller.rb
+++ b/app/controllers/milestones_controller.rb
@@ -21,7 +21,9 @@ class MilestonesController < ApplicationController
              end
 
     if @milestone.is_public || current_user?(@milestone.user)
+      @from_milestone_show = true
       @milestone_tasks = @milestone.tasks
+      @task = Task.new
     else
       flash[:alert] = "この星座は非公開です"
       redirect_to milestones_path

--- a/app/views/application/_flash.html.erb
+++ b/app/views/application/_flash.html.erb
@@ -1,4 +1,4 @@
-<div id="flash">
+<div id="flash" class="fixed m-5 top-0 left-0 right-0 z-50">
 <% if flash[:notice] %>
   <div role="alert" class="alert alert-success">
     <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 shrink-0 stroke-current" fill="none" viewBox="0 0 24 24">

--- a/app/views/milestones/index.html.erb
+++ b/app/views/milestones/index.html.erb
@@ -6,7 +6,9 @@
   <div class="relative z-10 min-h-screen space-y-5 rounded-t-[4rem] border-x-1 border-t-1 border-base-200 bg-base-300/30 p-8 text-center text-base-200 xl:text-xl">
 
     <!-- フラッシュメッセージ -->
-    <%= render 'flash' %>
+    <div id="flash" class="fixed m-5 top-0 left-0 right-0 z-50">
+      <%= render 'flash' %>
+    </div>
 
     <div class="text-center text-3xl text-base-200">
       <%= @user.name %>

--- a/app/views/milestones/show.html.erb
+++ b/app/views/milestones/show.html.erb
@@ -122,9 +122,27 @@
 
       <!-- タスク -->
       <input type="radio" name="my_tabs" class="tab" aria-label="タスク" />
-      <div class="tab-content border-base-300 bg-base-100 p-3">
-        <%= render "tasks/tasks", tasks: @milestone_tasks %>
-      </div>
+      <% if @milestone_tasks.present? %>
+        <div class="tab-content border-base-300 bg-base-100 p-3">
+          <%= render "tasks/tasks", tasks: @milestone_tasks %>
+
+          <div class="card flex items-center justify-center mb-4 size-full h-25 bg-base-300/40 shadow-xl/10">
+            <button class="size-full p-1 rounded-xl hover:cursor-pointer hover:bg-base-300/30 p-4" onclick="tasks_new_modal.showModal()">
+                <div class="flex items-center justify-center size-full">
+                  <span class="material-symbols-outlined">
+                    add_circle
+                  </span>
+                  追加
+                </div>
+            </button>
+          </div>
+
+        </div>
+      <% else %>
+        <div class="tab-content border-base-300 bg-base-100 px-3 py-10">
+          この星座にタスクは存在しません
+        </div>
+      <% end %>
     </div>
 
   </div>
@@ -137,6 +155,9 @@
 
 <% if current_user?(@milestone.user) %>
   <%= render 'milestones/milestone_edit_form', milestone: @milestone %>
+  <%= render "tasks/tasks_new_form", task: @task, milestones: [@milestone] %>
+  <%= turbo_frame_tag "task_edit_modal" %>
 <% end %>
 
+<%= turbo_frame_tag "tasks_show_modal" %>
 

--- a/app/views/milestones/show.html.erb
+++ b/app/views/milestones/show.html.erb
@@ -112,6 +112,7 @@
 
     <!-- タスクの表示部分 -->
     <div class="tabs tabs-lift">
+      <!-- チャート -->
       <input type="radio" name="my_tabs" class="tab" aria-label="チャート" checked="checked"  />
       <div class="tab-content border-base-300 bg-base-100 p-6">
         <div class="overflow-x-auto">
@@ -119,8 +120,11 @@
         </div>
       </div>
 
+      <!-- タスク -->
       <input type="radio" name="my_tabs" class="tab" aria-label="タスク" />
-      <div class="tab-content border-base-300 bg-base-100 p-6">属するタスク一覧</div>
+      <div class="tab-content border-base-300 bg-base-100 p-3">
+        <%= render "tasks/tasks", tasks: @milestone_tasks %>
+      </div>
     </div>
 
   </div>
@@ -134,3 +138,5 @@
 <% if current_user?(@milestone.user) %>
   <%= render 'milestones/milestone_edit_form', milestone: @milestone %>
 <% end %>
+
+

--- a/app/views/milestones/show.html.erb
+++ b/app/views/milestones/show.html.erb
@@ -113,7 +113,8 @@
     <% end %>
 
     <!-- タスクの表示部分 -->
-    <div class="tabs tabs-lift">
+    <div class="flex w-full items-center justify-center mb-10">
+    <div class="tabs tabs-lift w-xl">
       <!-- チャート -->
       <input type="radio" name="my_tabs" class="tab" aria-label="チャート" checked="checked"  />
       <div class="tab-content border-base-300 bg-base-100 p-6">
@@ -124,9 +125,10 @@
 
       <!-- タスク -->
       <input type="radio" name="my_tabs" class="tab" aria-label="タスク" />
-      <% if @milestone_tasks.present? %>
-        <div class="tab-content border-base-300 bg-base-100 p-3">
+      <div class="tab-content border-base-300 bg-base-100 p-3">
 
+        <% if current_user?(@milestone.user) %>
+          <!-- 新規作成ボタン -->
           <div class="card flex items-center justify-center mb-4 size-full h-25 bg-base-300/40 shadow-xl/10">
             <%= link_to new_task_path(milestone_from_milestone_show: @milestone), class: "size-full p-1 rounded-xl hover:cursor-pointer hover:bg-base-300/30 p-4", data: { turbo_frame: "tasks_new_modal"} do %>
               <div class="flex items-center justify-center size-full">
@@ -137,17 +139,15 @@
               </div>
             <% end %>
           </div>
+        <% end %>
 
-          <%= render "tasks/tasks", tasks: @milestone_tasks %>
+        <!-- タスク一覧 -->
+        <%= render "tasks/tasks", tasks: @milestone_tasks %>
 
         </div>
-      <% else %>
-        <div class="tab-content border-base-300 bg-base-100 px-3 py-10">
-          この星座にタスクは存在しません
-        </div>
-      <% end %>
     </div>
 
+  </div>
   </div>
 
   <!-- メニューバー -->

--- a/app/views/milestones/show.html.erb
+++ b/app/views/milestones/show.html.erb
@@ -6,7 +6,9 @@
   <div class="relative z-10 min-h-screen space-y-5 rounded-t-[4rem] border-x-1 border-t-1 border-base-200 bg-base-300/30 p-8 text-center text-lg md:text-xl">
 
     <!-- フラッシュメッセージ -->
-    <%= render 'flash' %>
+    <div id="flash" class="fixed m-5 top-0 left-0 right-0 z-50">
+      <%= render 'flash' %>
+    </div>
 
     <div class="flex items-center justify-center text-3xl">
       <div class="mr-2">
@@ -124,18 +126,19 @@
       <input type="radio" name="my_tabs" class="tab" aria-label="タスク" />
       <% if @milestone_tasks.present? %>
         <div class="tab-content border-base-300 bg-base-100 p-3">
-          <%= render "tasks/tasks", tasks: @milestone_tasks %>
 
           <div class="card flex items-center justify-center mb-4 size-full h-25 bg-base-300/40 shadow-xl/10">
-            <button class="size-full p-1 rounded-xl hover:cursor-pointer hover:bg-base-300/30 p-4" onclick="tasks_new_modal.showModal()">
-                <div class="flex items-center justify-center size-full">
-                  <span class="material-symbols-outlined">
-                    add_circle
-                  </span>
-                  追加
-                </div>
-            </button>
+            <%= link_to new_task_path(milestone_from_milestone_show: @milestone), class: "size-full p-1 rounded-xl hover:cursor-pointer hover:bg-base-300/30 p-4", data: { turbo_frame: "tasks_new_modal"} do %>
+              <div class="flex items-center justify-center size-full">
+                <span class="material-symbols-outlined">
+                  add_circle
+                </span>
+                追加
+              </div>
+            <% end %>
           </div>
+
+          <%= render "tasks/tasks", tasks: @milestone_tasks %>
 
         </div>
       <% else %>
@@ -155,8 +158,8 @@
 
 <% if current_user?(@milestone.user) %>
   <%= render 'milestones/milestone_edit_form', milestone: @milestone %>
-  <%= render "tasks/tasks_new_form", task: @task, milestones: [@milestone] %>
   <%= turbo_frame_tag "task_edit_modal" %>
+  <%= turbo_frame_tag "tasks_new_modal" %>
 <% end %>
 
 <%= turbo_frame_tag "tasks_show_modal" %>

--- a/app/views/tasks/_progress_button.html.erb
+++ b/app/views/tasks/_progress_button.html.erb
@@ -1,4 +1,5 @@
   <div id="progress_button_<%=task.id%>" class="flex w-3/10 max-w-20 justify-end">
+  <% if current_user?(task.user) %>
   <%= button_to update_progress_task_path(task), method: :patch, form: { data: { turbo: true } }, class: "btn btn-base-200 flex w-full h-auto aspect-square flex-col items-center justify-center rounded-xl" do %>
     <% if task.progress == "not_started" %>
       <div class="text-xs text-base-100 whitespace-nowrap">
@@ -16,5 +17,25 @@
       完了
       </div>
     <% end %>
+  <% end %>
+  <% else %>
+    <div class= "bg-base-200 flex w-full h-auto aspect-square flex-col items-center justify-center rounded-xl">
+      <% if task.progress == "not_started" %>
+        <div class="text-xs text-base-100 whitespace-nowrap">
+          <%= render "tasks/not_started_icon", color: task.milestone&.color %>
+          未着手
+        </div>
+      <% elsif task.progress == "in_progress" %>
+        <div class="text-xs text-base-100 whitespace-nowrap">
+          <%= render "tasks/in_progress_icon", color: task.milestone&.color %>
+          進行中
+        </div>
+      <% elsif task.progress == "completed" %>
+        <div class="text-xs text-base-100 whitespace-nowrap">
+          <%= render "tasks/completed_icon", color: task.milestone&.color %>
+          完了
+        </div>
+      <% end %>
+    </div>
   <% end %>
   </div>

--- a/app/views/tasks/_progress_button.html.erb
+++ b/app/views/tasks/_progress_button.html.erb
@@ -2,17 +2,17 @@
   <%= button_to update_progress_task_path(task), method: :patch, form: { data: { turbo: true } }, class: "btn btn-base-200 flex w-full h-auto aspect-square flex-col items-center justify-center rounded-xl" do %>
     <% if task.progress == "not_started" %>
       <div class="text-xs text-base-100 whitespace-nowrap">
-      <%= render "not_started_icon", color: task.milestone&.color %>
+      <%= render "tasks/not_started_icon", color: task.milestone&.color %>
       未着手
       </div>
     <% elsif task.progress == "in_progress" %>
       <div class="text-xs text-base-100 whitespace-nowrap">
-      <%= render "in_progress_icon", color: task.milestone&.color %>
+      <%= render "tasks/in_progress_icon", color: task.milestone&.color %>
       進行中
       </div>
     <% elsif task.progress == "completed" %>
       <div class="text-xs text-base-100 whitespace-nowrap">
-      <%= render "completed_icon", color: task.milestone&.color %>
+      <%= render "tasks/completed_icon", color: task.milestone&.color %>
       完了
       </div>
     <% end %>

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -27,10 +27,8 @@
 
     <% end %>
 
-    <% if current_user?(task.user) %>
       <!-- progressボタン -->
       <%= render "tasks/progress_button", task: task %>
-    <% end %>
   </div>
 
 </div>

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -29,7 +29,7 @@
 
     <% if current_user?(task.user) %>
       <!-- progressボタン -->
-      <%= render "progress_button", task: task %>
+      <%= render "tasks/progress_button", task: task %>
     <% end %>
   </div>
 

--- a/app/views/tasks/_task_edit_form.html.erb
+++ b/app/views/tasks/_task_edit_form.html.erb
@@ -1,11 +1,11 @@
 <%= turbo_frame_tag "task_edit_modal" do %>
   <dialog class="modal" <%= task_edit_modal_open ? 'open' : ' ' %> >
 
-    <!-- tasks/edit_modal.html.erbも同様に編集する -->
+    <!-- tasks/edit_modal.html.erbから編集する -->
     <!-- まずはturbo_frame_tagを使ってtasks/editでモーダルの部分を表示 -->
     <!-- tasks#updateでturbo_stremasを使って、モーダルの部分を_tasks_editファイルに置換しています -->
 
-    <!-- ここから貼り付け from "_tasks_edit_form.html" -->
+    <!-- ここから貼り付け from "tasks/edit.html.erb" -->
     <div id="turbo_update_false_target" class="modal-box max-h-[90vh]">
       <p class="pb-4 text-center">ESC or 下の(X)を押すと閉じます</p>
       <div class="flex w-full items-center justify-center">

--- a/app/views/tasks/_tasks.html.erb
+++ b/app/views/tasks/_tasks.html.erb
@@ -1,5 +1,5 @@
 <!-- 星座 -->
-<div class="mx-auto">
+<div id="tasks_content" class="mx-auto">
   <% tasks.each do |task| %>
     <%= render "tasks/task", task: task %>
   <% end %>

--- a/app/views/tasks/_tasks.html.erb
+++ b/app/views/tasks/_tasks.html.erb
@@ -1,7 +1,7 @@
 <!-- 星座 -->
 <div class="mx-auto">
   <% tasks.each do |task| %>
-    <%= render "task", task: task %>
+    <%= render "tasks/task", task: task %>
   <% end %>
 </div>
 

--- a/app/views/tasks/_tasks_new_form.html.erb
+++ b/app/views/tasks/_tasks_new_form.html.erb
@@ -11,17 +11,26 @@
           </div>
 
           <!-- エラーメッセージ -->
-          <%= render "error_messages", resource: @task %>
+          <%= render "error_messages", resource: task %>
 
           <!-- 編集フォーム -->
-          <%= form_for(@task, as: @task, url: tasks_path, html: { method: :post, class: "w-full mt-6 p-2" }) do |f| %>
+          <%= form_for(task, as: task, url: tasks_path, html: { method: :post, class: "w-full mt-6 p-2" }) do |f| %>
 
-            <label class="floating-label">
-              <%= f.collection_select :milestone_id, @milestones, :id, :title,
-                { include_blank: "Select Milestone" },
-                class: "select select-lg select-primary w-full text-base-100 bg-base-200" %>
-              <span class="floating-label-text">Milestone</span>
-            </label>
+            <% if @from_milestone_show %>
+              <label class="floating-label">
+                <%= f.collection_select :milestone_id, milestones, :id, :title,
+                  {:selected => "#{milestones.first.id}"},
+                  class: "select select-lg select-primary w-full text-base-100 bg-base-200" %>
+                <span class="floating-label-text">Milestone</span>
+              </label>
+            <% else %>
+              <label class="floating-label">
+                <%= f.collection_select :milestone_id, milestones, :id, :title,
+                  { include_blank: "Select Milestone" },
+                  class: "select select-lg select-primary w-full text-base-100 bg-base-200" %>
+                <span class="floating-label-text">Milestone</span>
+              </label>
+            <% end %>
 
             <label class="floating-label mt-10">
               <%= f.text_field :title,

--- a/app/views/tasks/_tasks_new_form.html.erb
+++ b/app/views/tasks/_tasks_new_form.html.erb
@@ -11,7 +11,7 @@
           </div>
 
           <!-- エラーメッセージ -->
-          <%= render "error_messages", resource: @task%>
+          <%= render "error_messages", resource: @task %>
 
           <!-- 編集フォーム -->
           <%= form_for(@task, as: @task, url: tasks_path, html: { method: :post, class: "w-full mt-6 p-2" }) do |f| %>

--- a/app/views/tasks/_tasks_new_form.html.erb
+++ b/app/views/tasks/_tasks_new_form.html.erb
@@ -1,4 +1,11 @@
+<%= turbo_frame_tag "tasks_new_modal" do %>
 <dialog id="tasks_new_modal" class="modal" <%= @task_new_modal_open ? 'open' : ' ' %> >
+
+  <!-- tasks/new_modal.html.erbから編集する -->
+  <!-- まずはturbo_frame_tagを使ってtasks/newでモーダルの部分を表示 -->
+  <!-- tasks#createでturbo_stremasを使って、モーダルの部分を_tasks_new_modalファイルに置換しています -->
+
+  <!-- ここから貼り付け from "tasks/new.html.erb" -->
   <div class="modal-box max-h-[90vh]">
     <p class="pb-4 text-center">ESC or 下の(X)を押すと閉じます</p>
     <div class="flex w-full items-center justify-center">
@@ -96,6 +103,7 @@
       </form>
     </div>
   </div>
+  <!-- ここまで貼り付け from "tasks/new.html.erb" -->
 
 </dialog>
-
+<% end %>

--- a/app/views/tasks/create.turbo_stream.erb
+++ b/app/views/tasks/create.turbo_stream.erb
@@ -1,0 +1,18 @@
+  <%= turbo_stream.replace "flash" do %>
+    <%= render "flash" %>
+  <% end %>
+
+  <% if @task_create_success %>
+    <%= turbo_stream.replace "tasks_new_modal" do %>
+      <%= render "tasks_new_form", task: Task.new, milestones: @milestones %>
+    <% end %>
+
+    <%= turbo_stream.prepend "tasks_content" do %>
+      <%= render "tasks/task", task: @task %>
+    <% end %>
+
+  <% else %>
+    <%= turbo_stream.replace "tasks_new_modal" do %>
+      <%= render "tasks_new_form", task: @task, milestones: @milestones, task_edit_modal_open: @task_edit_modal_open %>
+    <% end %>
+  <% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -21,9 +21,10 @@
         <!-- 未完了のタスク -->
         <input type="radio" name="my_tabs" class="tab w-1/6" aria-label="未完了" checked="checked"/>
         <div class="tab-content border-base-300 bg-base-100 p-3">
-          <!-- タスク -->
+
+          <!-- タスクの追加ボタン -->
           <div class="card flex items-center justify-center mb-4 size-full h-25 bg-base-300/40 shadow-xl/10">
-              <%= link_to new_task_path, class: "size-full p-1 rounded-xl hover:cursor-pointer hover:bg-base-300/30 p-4", data: { turbo_frame: "tasks_new_modal"} do %>
+            <%= link_to new_task_path, class: "size-full p-1 rounded-xl hover:cursor-pointer hover:bg-base-300/30 p-4", data: { turbo_frame: "tasks_new_modal"} do %>
               <div class="flex items-center justify-center size-full">
                 <span class="material-symbols-outlined">
                   add_circle
@@ -33,6 +34,7 @@
             <% end %>
           </div>
 
+          <!-- タスク -->
           <%= render "tasks", tasks: @not_completed_tasks %>
 
         </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -6,7 +6,7 @@
   <div class="relative z-10 min-h-screen space-y-5 rounded-t-[4rem] border-x-1 border-t-1 border-base-200 bg-base-300/30 p-8 text-center text-base-200 xl:text-xl">
 
     <!-- フラッシュメッセージ -->
-    <div id="flash" class="fixed top-0 left-0 right-0 z-50">
+    <div id="flash" class="fixed m-5 top-0 left-0 right-0 z-50">
       <%= render 'flash' %>
     </div>
 
@@ -22,18 +22,18 @@
         <input type="radio" name="my_tabs" class="tab w-1/6" aria-label="未完了" checked="checked"/>
         <div class="tab-content border-base-300 bg-base-100 p-3">
           <!-- タスク -->
-          <%= render "tasks", tasks: @not_completed_tasks %>
-
           <div class="card flex items-center justify-center mb-4 size-full h-25 bg-base-300/40 shadow-xl/10">
-            <button class="size-full p-1 rounded-xl hover:cursor-pointer hover:bg-base-300/30 p-4" onclick="tasks_new_modal.showModal()">
-                <div class="flex items-center justify-center size-full">
-                  <span class="material-symbols-outlined">
-                    add_circle
-                  </span>
-                  追加
-                </div>
-            </button>
+              <%= link_to new_task_path, class: "size-full p-1 rounded-xl hover:cursor-pointer hover:bg-base-300/30 p-4", data: { turbo_frame: "tasks_new_modal"} do %>
+              <div class="flex items-center justify-center size-full">
+                <span class="material-symbols-outlined">
+                  add_circle
+                </span>
+                追加
+              </div>
+            <% end %>
           </div>
+
+          <%= render "tasks", tasks: @not_completed_tasks %>
 
         </div>
 
@@ -54,5 +54,5 @@
   </div>
   <%= turbo_frame_tag "task_edit_modal" %>
   <%= turbo_frame_tag "tasks_show_modal" %>
-  <%= render "tasks/tasks_new_form", task: @task, milestones: @milestones %>
+  <%= turbo_frame_tag "tasks_new_modal" %>
 

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,9 +1,18 @@
+<%= turbo_frame_tag "tasks_new_modal" do %>
   <div data-controller="show-modal">
     <div data-show-modal-target="modal_top">
       <dialog data-show-modal-target="task_modal" id="tasks_new_modal" class="modal" <%= @task_new_modal_open ? 'open' : ' ' %> >
-        <div class="modal-box">
-          <div class="flex items-center justify-center">
-            <div class="card bg-base-300 w-2xl h-2xl p-5 flex justify-center z-10">
+
+
+        <!-- _tasks_new_form.html.erbも同様に編集する -->
+        <!-- まずはturbo_frame_tagを使ってtasks/newでモーダルの部分を表示 -->
+        <!-- tasks#createでturbo_stremasを使って、モーダルの部分を_tasks_new_modalファイルに置換しています -->
+
+        <!-- ここからコピー to "_tasks_new_form.html.erb" -->
+        <div class="modal-box max-h-[90vh]">
+          <p class="pb-4 text-center">ESC or 下の(X)を押すと閉じます</p>
+          <div class="flex w-full items-center justify-center">
+            <div class="card bg-base-300 w-full h-2xl p-3 flex justify-center z-10">
               <div>
 
                 <!-- タイトルタブ -->
@@ -12,17 +21,26 @@
                 </div>
 
                 <!-- エラーメッセージ -->
-                <%= render "error_messages", resource: @task%>
+                <%= render "error_messages", resource: @task %>
 
                 <!-- 編集フォーム -->
                 <%= form_for(@task, as: @task, url: tasks_path, html: { method: :post, class: "w-full mt-6 p-2" }) do |f| %>
 
-                  <label class="floating-label">
-                    <%= f.collection_select :milestone_id, @milestones, :id, :title,
-                      { include_blank: "Select Milestone" },
-                      class: "select select-lg select-primary w-full text-base-100 bg-base-200" %>
-                    <span class="floating-label-text">Milestone</span>
-                  </label>
+                  <% if @from_milestone_show %>
+                    <label class="floating-label">
+                      <%= f.collection_select :milestone_id, @milestones, :id, :title,
+                        {:selected => "#{@milestones.first.id}"},
+                        class: "select select-lg select-primary w-full text-base-100 bg-base-200" %>
+                      <span class="floating-label-text">Milestone</span>
+                    </label>
+                  <% else %>
+                    <label class="floating-label">
+                      <%= f.collection_select :milestone_id, @milestones, :id, :title,
+                        { include_blank: "Select Milestone" },
+                        class: "select select-lg select-primary w-full text-base-100 bg-base-200" %>
+                      <span class="floating-label-text">Milestone</span>
+                    </label>
+                  <% end %>
 
                   <label class="floating-label mt-10">
                     <%= f.text_field :title,
@@ -33,27 +51,28 @@
                     <span class="floating-label-text">Title</span>
                   </label>
 
-                  <div class="flex items-center justify-between mt-10">
-                    <label class="floating-label">
+                  <div class="flex justify-center">
+                    <label class="mt-5 w-50">
+                      <span class="text-base-200 text-sm">Start Date</span>
                       <%= f.date_field :start_date,
                         autocomplete: "Start Date",
                         placeholder: "Start Date",
-                        class: "textarea textarea-lg w-full text-base-100 bg-base-200 rounded-lg" %>
-                      <span class="floating-label-text">Start Date</span>
-                    </label>
+                        class: "text-base-200 bg-base-100 rounded-full p-3 w-full" %>
+                  </label>
+                  </div>
 
-                    <p class="text-2xl">~</p>
 
-                    <label class="floating-label">
+                  <div class="flex justify-center">
+                    <label class="mt-5 w-50">
+                      <span class="text-base-200 text-sm">End Date</span>
                       <%= f.date_field :end_date,
                         autocomplete: "End Date",
                         placeholder: "End Date",
-                        class: "textarea textarea-lg w-full text-base-100 bg-base-200 rounded-lg" %>
-                      <span class="floating-label-text">End Date</span>
-                    </label>
+                        class: "text-base-200 bg-base-100 rounded-full p-3 w-full" %>
+                  </label>
                   </div>
 
-                  <label class="floating-label mt-10">
+                  <label class="floating-label mt-5">
                     <%= f.text_area :description,
                       autocomplete: "description",
                       placeholder: "Description",
@@ -61,7 +80,7 @@
                     <span class="floating-label-text">Description</span>
                   </label>
 
-                  <label class="floating-label mt-10">
+                  <label class="floating-label mt-5">
                     <%= f.collection_select :progress, Task.progresses.keys, :to_s, :humanize,
                       { include_blank: "Select Progress" },
                       class: "select select-lg select-primary w-full text-base-100 bg-base-200" %>
@@ -87,5 +106,9 @@
             </form>
           </div>
         </div>
+      <!-- ここまでコピー to "_tasks_new_form.html.erb" -->
 
       </dialog>
+    </div>
+    </div>
+    <% end %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -103,18 +103,20 @@
                   </div>
 
                   <!-- アクションボタン -->
-                  <div class="flex h-12 w-full mt-10 justify-center text-neutral">
-                    <div class="btn btn-error mr-5 h-12 w-25 md:w-42">
-                      削除
+                  <% if current_user?(@task.user) %>
+                    <div class="flex h-12 w-full mt-10 justify-center text-neutral">
+                      <div class="btn btn-error mr-5 h-12 w-25 md:w-42">
+                        削除
+                      </div>
+                      <div class="btn btn-accent h-12 w-25 md:w-42">
+                        <%= link_to edit_task_path(@task), class: "w-full h-full flex justify-center items-center", data: { turbo_frame: "task_edit_modal"} do %>
+                          <p>
+                          編集
+                          </p>
+                        <% end %>
+                      </div>
                     </div>
-                    <div class="btn btn-accent h-12 w-25 md:w-42">
-                      <%= link_to edit_task_path(@task), class: "w-full h-full flex justify-center items-center", data: { turbo_frame: "task_edit_modal"} do %>
-                        <p>
-                        編集
-                        </p>
-                      <% end %>
-                    </div>
-                  </div>
+                  <% end %>
                 </div>
 
               </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,7 +6,9 @@
   <div class="z-10 space-y-5 bg-base-300/30  border-t-1 border-x-1 border-base-200 relative p-8 text-center rounded-t-[4rem] xl:text-xl">
 
     <!-- フラッシュメッセージ -->
-    <%= render 'flash' %>
+    <div id="flash" class="fixed m-5 top-0 left-0 right-0 z-50">
+      <%= render 'flash' %>
+    </div>
 
     <div class=" text-center text-3xl">
       <%= @user.name %>


### PR DESCRIPTION

# 概要

<!-- レビュアーが理解できるように、このプルリクの概要と共に、どうしてそうなったのか背景を以下に書いておくとgood -->

milestones/showにそのマイルに属するtasks一覧を追加しました。
また、その画面内でのtasks#newの動作を調整するために、tasks#newをturbo_frame, tasks#createをturbo_streamを使用する形に変更しました。


# 細かな変更点

<!-- コード自体の変更についてサマリーを記載する。レビュアーが「あれ？どうして概要に書いてないけど、変更したんだっけ？」と思わないように説明するのがポイントです -->

- files | 13    7 | 830312db add:タスク詳細にそのタスクに属するタスクを表示 ymzkna, 2 hours ago
│ app/views/milestones/show.html.erb 7, 1
-- タスクタブ内にtasksの一覧表示部分を配置
│app/views/tasks/_progress_button.html.erb 3, 3
-- views/tasksディレクトリ外からアクセスされることによって、内部に記載してあるパーシャルのパス表記を変更しました
│app/views/tasks/_task.html.erb 1, 1
-- 同上です
│app/views/tasks/_tasks.html.erb 1, 1
-- 同上です
│app/views/tasks/_tasks_new_form.html.erb 1, 1
-- 必要な場所にスペースを配置

- M  3 files | 43   11 | 5c8b2e9e add:milestone/showにタスク新規作成機能を追加しました YmzknA, 2 hours ago
│app/controllers/milestones_controller.rb 2, 0
-- milestones#showに@from_milestone_show = true, @task = Task.newを設定
-- @from_milestone_show = tureは後の実装で不要になったので削除されることになりました
│app/views/tasks/_tasks_new_form.html.erb 17, 8
-- milestones/showからアクセスした場合は、そのmilestoneのみを選択肢に表示させる、または最初から選択されている状態になるようにしました

- M  1 file  | 14    9 | 35f0c291 fix:tasks#newと#createをturbo_frame, turbo_streamを使用するように変更 YmzknA, 14 minutes ago
│app/controllers/tasks_controller.rb 14, 9
-- #newをturbo_frame, #createをturbo_streamを使用するように変更しました

- M  1 file  | 1     1 | 36f17304 fix:表示位置とサイズを調整 YmzknA, 13 minutes ago
│app/views/application/_flash.html.erb 1, 1
│app/views/milestones/index.html.erb 3, 1
│app/views/milestones/show.html.erb 14, 11
│app/views/users/show.html.erb 3, 1
-- フラッシュの表示の変更

- M  4 files | 73   24 | 934292d7 fix:tasks#newと#createがturboになるにあたっての変更 YmzknA, 11 minutes ago
│app/views/tasks/_tasks.html.erb 1, 1
-- idにtasks_contentを付与しstreamの対象に
│app/views/tasks/_tasks_new_form.html.erb 9, 1
-- turbo_frameタグを設置しturboframeで置換されるようにします
-- これはstreamで置換した後の要素にturbo_frameタグが存在しなくなる現象を防ぐためです
│app/views/tasks/create.turbo_stream.erb 18, 0
-- streamでcreate後に置換する対象を明示するファイル
│app/views/tasks/new.html.erb 45, 22
-- 少し複雑な実装になっているので、コメントを記載して編集忘れ防止

- M  1 file  | 12   12 | 6a2b6aaa fix:newへのリンクをturbo_frameへと変更 YmzknA, 11 minutes ago
│app/views/tasks/index.html.erb 12, 12
-- フラッシュメッセージの表示を調整
-- tasks#newにturboframeでリンク

- M  1 file  | 11   19 | 60635a2f fix:rubocop YmzknA, 16 minutes ago
│app/controllers/tasks_controller.rb 11, 19
-- rubocopで指摘のあったコードが長すぎるという部分を修正

- M  1 file  | 13   11 | 97d17c00 fix:所有者ではないときに、アクションボタンを表示しないように YmzknA, 16 minutes ago
│app/views/tasks/show.html.erb 13, 11
-- current_user?(user)がtrueの時だけ、削除・編集ボタンを表示するように


- M  1 file  | 9     9 | 75d5a48c fix:milestones/showのtask一覧のサイズが大きかった問題を修正 YmzknA, 3 minutes ago
│app/views/milestones/show.html.erb 9, 9
-- タブ要素のサイズが大きかったので、tasks/indexのサイズと統一

- M  1 file  | 21    0 | da6dd3d3 add:progressボタンを、ほかのユーザーにはprogress状態を表示するだけにしました YmzknA, 3 minutes ago
│app/views/tasks/_progress_button.html.erb 21, 0
-- current_user?(user)がtrueの場合は、purogressを表示するだけの要素に変更

- M  1 file  | 0     2 | bfc31e02 fix:progressボタンのロジック変更にあたり、ここでの判定は不要になりました YmzknA, 2 minutes ago
│app/views/tasks/_task.html.erb 0, 2
-- current_user?で表示を判定していましたが、progress_button内で分岐したため前側の部分は削除

- M  1 file  | 4     2 | e9130882 (HEAD -> feature/tasks_index_on_milestone_show, origin/feature/tasks_index_on_milestone_show) fix:コメントの修正 YmzknA, 74 seconds ago
│app/views/tasks/index.html.erb 4, 2
-- 少しわかりにくいと思ったのでコメントを入れました

- M  1 file  | 0     1 | 371dfdfc (HEAD -> feature/tasks_index_on_milestone_show, origin/feature/tasks_index_on_milestone_show) fix:不要になった変数を削除 YmzknA, 41 seconds ago
│app/controllers/milestones_controller.rb 0, 1
## スクリーンショット
![image](https://github.com/user-attachments/assets/370263c2-b738-4df5-b7f9-7e98bc4acac6)

<!-- Command + Shift + Control + 4 でスクリーンショットして Command + V でここに貼り付けるのが楽。以下のフォーマットは必要に応じて使ってください -->
<!-- github copilot レビューは日本語でお願いします -->
