### PR TITLE
tasks削除機能を追加しました closes #31

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -85,8 +85,7 @@ class TasksController < ApplicationController
   # DELETE /tasks/1
   def destroy
     @task.destroy!
-
-    redirect_to tasks_path, status: :see_other, notice: "Task was successfully destroyed."
+    flash.now[:notice] = "タスクを削除しました"
   end
 
   def update_progress

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -1,4 +1,4 @@
-<div id="tasks_update_replace_task_<%=task.id%>" class="card mb-4 w-full p-4 bg-base-300/40 shadow-xl/10">
+<div id="task_<%=task.id%>" class="card mb-4 w-full p-4 bg-base-300/40 shadow-xl/10">
 
   <div class="flex w-full items-center text-left">
     <%= link_to task_path(task), class: "w-full p-1 rounded-xl hover:bg-base-300/30", data: { turbo_frame: "tasks_show_modal"} do %>

--- a/app/views/tasks/_tasks_show_modal_content.html.erb
+++ b/app/views/tasks/_tasks_show_modal_content.html.erb
@@ -93,7 +93,7 @@
           <!-- アクションボタン -->
           <% if current_user?(@task.user) %>
             <div class="flex h-12 w-full mt-10 justify-center text-neutral">
-              <%= button_to "削除", task_path(@task), method: :delete, data: { turbo_confirm: "本当に削除しますか？", turbo_stream: true }, class: "btn btn-error h-12 w-25 md:w-42" %>
+              <%= button_to "削除", task_path(@task), method: :delete, data: { turbo_confirm: "本当に削除しますか？", turbo_stream: true }, class: "btn btn-error h-12 w-25 mr-5 md:w-42" %>
 
               <div class="btn btn-accent h-12 w-25 md:w-42">
                 <%= link_to edit_task_path(@task), class: "w-full h-full flex justify-center items-center", data: { turbo_frame: "tasks_edit_modal"} do %>

--- a/app/views/tasks/_tasks_show_modal_content.html.erb
+++ b/app/views/tasks/_tasks_show_modal_content.html.erb
@@ -93,9 +93,8 @@
           <!-- アクションボタン -->
           <% if current_user?(@task.user) %>
             <div class="flex h-12 w-full mt-10 justify-center text-neutral">
-              <div class="btn btn-error mr-5 h-12 w-25 md:w-42">
-                削除
-              </div>
+              <%= button_to "削除", task_path(@task), method: :delete, data: { turbo_confirm: "本当に削除しますか？", turbo_stream: true }, class: "btn btn-error h-12 w-25 md:w-42" %>
+
               <div class="btn btn-accent h-12 w-25 md:w-42">
                 <%= link_to edit_task_path(@task), class: "w-full h-full flex justify-center items-center", data: { turbo_frame: "tasks_edit_modal"} do %>
                   <p>

--- a/app/views/tasks/destroy.turbo_stream.erb
+++ b/app/views/tasks/destroy.turbo_stream.erb
@@ -1,0 +1,9 @@
+  <%= turbo_stream.remove @task %>
+
+  <%= turbo_stream.replace "flash" do %>
+    <%= render "flash" %>
+  <% end %>
+
+  <%= turbo_stream.replace "tasks_show_modal" do %>
+    <%= turbo_frame_tag "tasks_show_modal" %>
+  <% end %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -7,10 +7,7 @@
         <!-- まずはturbo_frame_tagを使ってtasks/showでモーダルの部分を表示 -->
         <!-- tasks#updateでturbo_stremasを使って、モーダルの部分を_tasks_showファイルに置換しています -->
 
-        <!-- ここから貼り付け to "_tasks_show.html" -->
         <%= render "tasks/tasks_show_modal_content", task: @task %>
-
-        <!-- ここまで貼り付け to "_tasks_show.html" -->
 
         <form method="dialog" class="modal-backdrop">
           <button>close</button>

--- a/app/views/tasks/update.turbo_stream.erb
+++ b/app/views/tasks/update.turbo_stream.erb
@@ -16,6 +16,4 @@
     <%= render "tasks_show_modal", task: @task, tasks_show_modal_open: @tasks_show_modal_open %>
   <% end %>
 
-  <%= turbo_stream.replace "tasks_update_replace_task_#{@task.id}" do %>
-    <%= render "task", task: @task %>
-  <% end %>
+  <%= turbo_stream.replace @task %>


### PR DESCRIPTION
<!-- github copilot レビューは日本語でお願いします -->
# 概要

<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->

task削除機能を追加しました。
turbo_streamで削除後の要素の置換を行っています。


# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイントです -->


- app/controllers/tasks_controller.rb
  - 削除メソッドを、turbo_streamを使用するようにしました
- app/views/tasks/_tasks_show_modal_content.html.erb
  - 削除ボタンを配置しました
- app/views/tasks/destroy.turbo_stream.erb
  - 置換要素を記載しました。
- app/views/tasks/_task.html.erb
  - idを変更し、turbo_streamでの記載をシンプルに
- app/views/tasks/update.turbo_stream.erb
  - 上記の変更に伴い記載をシンプルに変更
- app/views/tasks/_tasks_show_modal_content.html.erb
  - ボタン間の隙間を追加
- app/views/tasks/show.html.erb
  - 不要なコメントを削除

<!-- github copilot レビューは日本語でお願いします -->

