### PR TITLE
Feature/mileston to completed

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -65,3 +65,6 @@ Metrics/MethodLength:
 
 Metrics/AbcSize:
   Max: 40
+
+Metrics/ClassLength:
+  Max: 150

--- a/app/controllers/milestones_controller.rb
+++ b/app/controllers/milestones_controller.rb
@@ -95,6 +95,14 @@ class MilestonesController < ApplicationController
     redirect_to @milestone
   end
 
+  def show_complete_page
+    @milestone = Milestone.find(params[:id])
+  end
+
+  def complete
+  end
+
+
   private
 
   def set_milestone

--- a/app/controllers/milestones_controller.rb
+++ b/app/controllers/milestones_controller.rb
@@ -100,8 +100,17 @@ class MilestonesController < ApplicationController
   end
 
   def complete
-  end
+    @milestone = Milestone.find(params[:id])
+    logger.swim(@milestone.progress)
+    flash[:notice] = "星座が完成しました"
+    @milestone_complete_success = true
 
+    # if @milestone.update(progress: "completed", completed_comment: params[:milestone][:completed_comment])
+    #   flash[:notice] = "星座を完了しました"
+    # else
+    #   flash[:alert] = "星座の完了に失敗しました"
+    # end
+  end
 
   private
 
@@ -117,7 +126,8 @@ class MilestonesController < ApplicationController
       :is_public,
       :is_on_chart,
       :start_date,
-      :end_date
+      :end_date,
+      :completed_comment
     ).merge(user_id: current_user.id)
   end
 

--- a/app/controllers/milestones_controller.rb
+++ b/app/controllers/milestones_controller.rb
@@ -1,5 +1,5 @@
 class MilestonesController < ApplicationController
-  before_action :set_milestone, only: [:show, :edit, :update, :destroy]
+  before_action :set_milestone, only: [:show, :edit, :update, :destroy, :complete, :show_complete_page]
   before_action :authenticate_user!, except: [:show]
   before_action :ensure_correct_user, only: [:edit, :update, :destroy]
 
@@ -95,12 +95,9 @@ class MilestonesController < ApplicationController
     redirect_to @milestone
   end
 
-  def show_complete_page
-    @milestone = Milestone.find(params[:id])
-  end
+  def show_complete_page; end
 
   def complete
-    @milestone = Milestone.find(params[:id])
     @milestone.constellation = Constellation.all.sample
     @milestone.progress = "completed"
     @milestone.completed_comment = params[:milestone][:completed_comment]

--- a/app/controllers/milestones_controller.rb
+++ b/app/controllers/milestones_controller.rb
@@ -101,15 +101,19 @@ class MilestonesController < ApplicationController
 
   def complete
     @milestone = Milestone.find(params[:id])
-    logger.swim(@milestone.progress)
-    flash[:notice] = "星座が完成しました"
-    @milestone_complete_success = true
+    @milestone.constellation = Constellation.all.sample
+    @milestone.progress = "completed"
+    @milestone.completed_comment = params[:milestone][:completed_comment]
 
-    # if @milestone.update(progress: "completed", completed_comment: params[:milestone][:completed_comment])
-    #   flash[:notice] = "星座を完了しました"
-    # else
-    #   flash[:alert] = "星座の完了に失敗しました"
-    # end
+    if @milestone.save
+      @milestone_complete_success = true
+      @completed_page_modal_open = true
+      flash.now[:notice] = "星座が完成しました"
+    else
+      @milestone_complete_success = false
+      @show_complete_page_modal_open = true
+      flash[:alert] = "星座の完成に失敗しました"
+    end
   end
 
   private

--- a/app/models/milestone.rb
+++ b/app/models/milestone.rb
@@ -6,7 +6,16 @@ class Milestone < ApplicationRecord
   validates :title, presence: true
   validates :start_date, presence: true, if: -> { is_on_chart }
   validates :end_date, presence: true, if: -> { is_on_chart }
+  validates :progress, presence: true
+  validates :color, presence: true
+  validates :completed_comment, length: { maximum: 50 }, allow_blank: true
+  validates :is_public, inclusion: { in: [true, false] }
+  validates :is_on_chart, inclusion: { in: [true, false] }
 
+  # Enum for progress status
+  # :not_started = 0
+  # :in_progress = 1
+  # :completed = 2
   enum progress: [:not_started, :in_progress, :completed]
 
   def completed_tasks_percentage

--- a/app/views/milestones/_completed_page.html.erb
+++ b/app/views/milestones/_completed_page.html.erb
@@ -1,0 +1,60 @@
+  <dialog id="complete_page_modal" class="modal" <%= @completed_page_modal_open ? 'open' : ' ' %> >
+    <div class="modal-box max-h-[90vh]">
+      <p class="text-center pb-4">ESC or 下の(X)を押すと閉じます</p>
+      <div class="flex w-full items-center justify-center">
+        <div class="card z-10 flex h-2xl w-full justify-center bg-base-300 p-5 text-center md:w-2xl">
+          <div>
+
+            <!-- タスク詳細表示 -->
+            <div class="space-y-5">
+              <div class="flex items-center justify-center text-secondary">
+                <p class="text-xl">星座が完成しました</p>
+              </div>
+
+              <!-- 星座名 -->
+              <div class="flex items-center justify-center text-xl">
+                <div class="mr-2">
+                  <%= render "complete_stars_icon", { width: 35, height: 35, color: @milestone.color } %>
+                </div>
+                <%= "#{@milestone.title} 座" %>
+              </div>
+
+              <div class="text-3xl">
+              </div>
+              <div class="mx-auto flex justify-center items-center rounded-full h-52 w-52 bg-base-200">
+                <%= image_tag @milestone.constellation.image_name, class: "h-50 w-50 mask mask-circle" %>
+              </div>
+              <p><%= @milestone.constellation.name %>のアイコンが<br>付与されました</p>
+
+
+              <!-- 一言コメント -->
+              <div class="flex w-full items-center justify-center">
+                <div class="card w-full text-neutral">
+                  <p class="card-title h-5 pl-2 text-sm text-primary">一言コメント</p>
+                  <div class="flex min-h-24 w-full items-center justify-center rounded-xl bg-primary p-3">
+                    <%= @milestone.completed_comment.present? ? @milestone.completed_comment : "コメントはありません" %>
+                  </div>
+                </div>
+              </div>
+
+              <button class="btn btn-neutral rounded-lg px-3">
+                <%= image_tag 'x-logo.png', class: 'h-6 w-6' %>
+                <p class=" text-xs">完成をシェアする</p>
+              </button>
+
+            </div>
+
+          </div>
+        </div>
+      </div>
+      <div class="modal-action flex justify-center">
+        <form method="dialog">
+          <button class="btn btn-accent px-9">
+            <span class="material-symbols-outlined">
+              close
+            </span>
+          </button>
+        </form>
+      </div>
+    </div>
+  </dialog>

--- a/app/views/milestones/_milestone.html.erb
+++ b/app/views/milestones/_milestone.html.erb
@@ -1,0 +1,56 @@
+<div id="milestone_<%=milestone.id%>" class="card mb-4 w-full p-4 bg-base-300/40 shadow-xl/10">
+
+  <div class="mb-4 flex w-full items-center text-left">
+    <%= link_to milestone_path(milestone), class: "w-full p-1 rounded-xl hover:bg-base-300/30" do %>
+      <!-- タイトル, 日付, マーク -->
+      <div class="flex w-full">
+        <% if completed %>
+          <%= render "milestones/complete_stars_icon", color: milestone.color, width: 40, height: 40 %>
+        <% else %>
+          <div class="hidden sm:flex sm:items-center">
+            <%= render "stars_icon", color: milestone.color, width: 40, height: 40 %>
+          </div>
+          <div class="flex items-center sm:hidden">
+            <%= render "stars_icon", color: milestone.color %>
+          </div>
+        <% end %>
+
+        <div class="ml-2 w-7/10">
+          <p class="text-lg"><%= milestone.title %></p>
+          <p class="text-sm"><%= to_short_date(milestone&.start_date) %> ~ <%= to_short_date(milestone&.end_date) %></p>
+        </div>
+      </div>
+
+      <!-- 詳細 -->
+      <div class="text-left mt-1">
+        <% if milestone.description.present? %>
+          <p class="text-lg"><%= milestone.description.truncate(20) %></p>
+        <% else %>
+          <p class="text-lg">詳細はありません</p>
+        <% end %>
+      </div>
+
+
+    <% end %>
+
+    <% if !completed && milestone.completed_tasks_percentage == 100 && current_user?(milestone.user) %>
+      <!-- 完了ボタン -->
+      <div class="flex w-3/10 max-w-20 justify-end">
+        <%= link_to show_complete_page_milestone_path(milestone), data: { turbo_frame: "show_complete_page_modal" }, class: "btn btn-base-200 flex  w-full h-auto aspect-square flex-col items-center justify-center rounded-xl" do %>
+          <%= render "milestones/complete_stars_icon", color: milestone.color %>
+          <div class="text-xs text-base-100 whitespace-nowrap">
+            完成する
+          </div>
+        <% end %>
+      </div>
+
+    <% end %>
+  </div>
+
+
+  <% if !completed %>
+    <!-- 進捗 -->
+    <%= render "milestones/milestone_completed_percent_bar", milestone: milestone, milestone_tasks: milestone.tasks.all %>
+  <% end %>
+
+</div>

--- a/app/views/milestones/_milestones.html.erb
+++ b/app/views/milestones/_milestones.html.erb
@@ -1,62 +1,7 @@
 
 <!-- 星座 -->
-<div class="mx-auto">
+<div id="milestones_contet" class="mx-auto">
   <% milestones.each do |milestone| %>
-    <div class="card mb-4 w-full p-4 bg-base-300/40 shadow-xl/10">
-
-      <div class="mb-4 flex w-full items-center text-left">
-        <%= link_to milestone_path(milestone), class: "w-full p-1 rounded-xl hover:bg-base-300/30" do %>
-          <!-- タイトル, 日付, マーク -->
-          <div class="flex w-full">
-            <% if completed %>
-              <%= render "milestones/complete_stars_icon", color: milestone.color, width: 40, height: 40 %>
-            <% else %>
-              <div class="hidden sm:flex sm:items-center">
-            <%= render "stars_icon", color: milestone.color, width: 40, height: 40 %>
-              </div>
-              <div class="flex items-center sm:hidden">
-                <%= render "stars_icon", color: milestone.color %>
-              </div>
-            <% end %>
-
-            <div class="ml-2 w-7/10">
-              <p class="text-lg"><%= milestone.title %></p>
-                <p class="text-sm"><%= to_short_date(milestone&.start_date) %> ~ <%= to_short_date(milestone&.end_date) %></p>
-            </div>
-          </div>
-
-          <!-- 詳細 -->
-          <div class="text-left mt-1">
-            <% if milestone.description.present? %>
-              <p class="text-lg"><%= milestone.description.truncate(20) %></p>
-            <% else %>
-              <p class="text-lg">詳細はありません</p>
-            <% end %>
-          </div>
-
-
-        <% end %>
-
-        <% if !completed && milestone.completed_tasks_percentage == 100 && current_user?(milestone.user) %>
-          <!-- 完了ボタン -->
-          <div class="flex w-3/10 max-w-20 justify-end">
-            <%= link_to show_complete_page_milestone_path(milestone), data: { turbo_frame: "milestones_complete_page_modal" }, class: "btn btn-base-200 flex  w-full h-auto aspect-square flex-col items-center justify-center rounded-xl" do %>
-              <%= render "milestones/complete_stars_icon", color: milestone.color %>
-              <div class="text-xs text-base-100 whitespace-nowrap">
-                完了する
-              </div>
-            <% end %>
-          </div>
-
-        <% end %>
-      </div>
-
-
-      <% if !completed %>
-        <!-- 進捗 -->
-          <%= render "milestones/milestone_completed_percent_bar", milestone: milestone, milestone_tasks: milestone.tasks.all %>
-      <% end %>
-
-    </div>
+    <%= render "milestones/milestone", milestone: milestone, completed: completed %>
   <% end %>
 </div>

--- a/app/views/milestones/_milestones.html.erb
+++ b/app/views/milestones/_milestones.html.erb
@@ -40,7 +40,7 @@
         <% if !completed && milestone.completed_tasks_percentage == 100 && current_user?(milestone.user) %>
           <!-- 完了ボタン -->
           <div class="flex w-3/10 max-w-20 justify-end">
-            <%= link_to user_check_path, class: "btn btn-base-200 flex  w-full h-auto aspect-square flex-col items-center justify-center rounded-xl" do %>
+            <%= link_to show_complete_page_milestone_path(milestone), data: { turbo_frame: "milestones_complete_page_modal" }, class: "btn btn-base-200 flex  w-full h-auto aspect-square flex-col items-center justify-center rounded-xl" do %>
               <%= render "milestones/complete_stars_icon", color: milestone.color %>
               <div class="text-xs text-base-100 whitespace-nowrap">
                 完了する

--- a/app/views/milestones/_milestones.html.erb
+++ b/app/views/milestones/_milestones.html.erb
@@ -1,6 +1,6 @@
 
 <!-- 星座 -->
-<div id="milestones_contet" class="mx-auto">
+<div id="milestones_content" class="mx-auto">
   <% milestones.each do |milestone| %>
     <%= render "milestones/milestone", milestone: milestone, completed: completed %>
   <% end %>

--- a/app/views/milestones/_show_complete_page_modal.html.erb
+++ b/app/views/milestones/_show_complete_page_modal.html.erb
@@ -1,0 +1,9 @@
+<%= turbo_frame_tag "show_complete_page_modal" do %>
+  <dialog id="milestones_complete_page_modal" class="modal" <%= @milestone_new_modal_open ? 'open' : ' ' %> >
+
+    <!-- まずはturbo_frame_tagを使ってmilestones/show_complete_pageでモーダルの部分を表示 -->
+    <!-- milestones#completeでturbo_stremasを使って、モーダルの部分をこのファイルに更新しています -->
+    <%= render "milestones/show_complete_page_modal_content", milestone: @milestone %>
+
+  </dialog>
+<% end %>

--- a/app/views/milestones/_show_complete_page_modal.html.erb
+++ b/app/views/milestones/_show_complete_page_modal.html.erb
@@ -2,7 +2,7 @@
   <dialog id="milestones_complete_page_modal" class="modal" <%= @show_complete_page_modal_open ? 'open' : ' ' %> >
 
     <!-- まずはturbo_frame_tagを使ってmilestones/show_complete_pageでモーダルの部分を表示 -->
-    <!-- milestones#completeでturbo_stremasを使って、モーダルの部分をこのファイルに更新しています -->
+    <!-- milestones#completeでturbo_streamsを使って、モーダルの部分をこのファイルに更新しています -->
     <%= render "milestones/show_complete_page_modal_content", milestone: @milestone %>
 
   </dialog>

--- a/app/views/milestones/_show_complete_page_modal.html.erb
+++ b/app/views/milestones/_show_complete_page_modal.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag "show_complete_page_modal" do %>
-  <dialog id="milestones_complete_page_modal" class="modal" <%= @milestone_new_modal_open ? 'open' : ' ' %> >
+  <dialog id="milestones_complete_page_modal" class="modal" <%= @show_complete_page_modal_open ? 'open' : ' ' %> >
 
     <!-- まずはturbo_frame_tagを使ってmilestones/show_complete_pageでモーダルの部分を表示 -->
     <!-- milestones#completeでturbo_stremasを使って、モーダルの部分をこのファイルに更新しています -->

--- a/app/views/milestones/_show_complete_page_modal_content.html.erb
+++ b/app/views/milestones/_show_complete_page_modal_content.html.erb
@@ -10,7 +10,7 @@
             <p class="text-xl">星座を完成させる</p>
           </div>
 
-          <!-- マイルストーン -->
+          <!-- 星座名 -->
           <div class="flex items-center justify-center text-xl">
             <div class="mr-2">
               <%= render "stars_icon", { width: 35, height: 35, color: @milestone.color } %>
@@ -18,80 +18,41 @@
             <%= @milestone.title %>
           </div>
 
-          <!-- タイトル -->
-          <div class="flex w-full items-center justify-center">
-            <div class="card w-full text-neutral">
-              <p class="card-title h-5 pl-2 text-sm text-primary">Title</p>
-              <div class="flex w-full items-center justify-center rounded-xl bg-primary p-3">
-                <%= @milestone.title %>
-              </div>
-            </div>
-          </div>
+          <!-- エラーメッセージ -->
+          <%= render "error_messages", resource: @milestone %>
 
+          <!-- 編集フォーム -->
+          <%= form_for(@milestone, as: @milestone, url: complete_milestone_path(@milestone), html: { method: :patch, class: "w-full mt-10 p-2" }) do |f| %>
 
-          <!-- 期間 -->
-          <% if @milestone.start_date.present? || @milestone.end_date.present? %>
-            <div class="flex w-full justify-between px-5 text-neutral">
-              <div class="card flex h-full w-2/5 flex-col justify-center bg-primary p-2">
-                <div>
-                  <%= @milestone.start_date&.year %>年
+            <label class="floating-label">
+              <%= f.text_area :completed_comment,
+                autofocus: true,
+                autocomplete: "completed_comment",
+                placeholder: "一言コメント(50文字まで)",
+                maxlength: 50,
+                class: "input input-lg h-30 md:h-20 rounded-xl input-primary w-full text-base-100 bg-base-200 whitespace-normal" %>
+                <span class="floating-label-text">一言コメント(50文字まで)</span>
+            </label>
+
+            <div class="relative size-full flex justify-center items-center mt-10">
+              <%= f.submit "", class:"z-10 size-20 rounded-xl hover:cursor-pointer hover:bg-base-100/20" %>
+              <div class="absolute size-20 bg-base-200 flex flex-col justify-center items-center rounded-xl">
+                <div class="flex items-center justify-center">
+                  <%= render "milestones/complete_stars_icon", color: milestone.color %>
                 </div>
-                <div class="w-full font-bold md:text-2xl">
-                  <%= to_short_date(@milestone.start_date) %>
-                </div>
-              </div>
-              <div class="flex w-1/5 items-center justify-center">
-                <p class="w-full text-5xl text-primary">~</p>
-              </div>
-              <div class="card flex h-full w-2/5 flex-col justify-center bg-primary p-2">
-                <%= @milestone.end_date&.year %>年<br>
-                <div class="w-full font-bold md:text-2xl">
-                  <%= to_short_date(@milestone.end_date) %>
+                <div class="text-xs text-base-100 whitespace-nowrap">
+                  完成
                 </div>
               </div>
             </div>
-          <% else %>
-            <div class="flex w-full justify-center">
-              <div class="card w-full bg-primary p-10 text-neutral">
-                日付は設定されていません
-              </div>
-            </div>
-          <% end %>
 
-          <!-- 説明 -->
-          <div class="flex w-full items-center justify-center">
-            <div class="card w-full text-neutral">
-              <p class="card-title h-5 pl-2 text-sm text-primary">Description</p>
-              <div class="flex min-h-24 w-full items-center justify-center rounded-xl bg-primary p-3">
-                <%= @milestone.description.present? ? @milestone.description : "説明はありません" %>
-              </div>
-            </div>
-          </div>
 
-          <!-- 進捗状況 -->
-          <div class="flex w-full items-center justify-center">
-            <div class="card w-full text-neutral">
-              <p class="card-title h-5 pl-2 text-sm text-primary">Progress</p>
-              <div class="flex w-full items-center justify-center rounded-xl bg-primary p-3">
-                <%= @milestone.progress %>
-              </div>
-            </div>
-          </div>
+            <% end %>
 
-          <!-- アクションボタン -->
-          <% if current_user?(@milestone.user) %>
-            <div class="flex h-12 w-full mt-10 justify-center text-neutral">
-              <%= button_to "削除", milestone_path(@milestone), method: :delete, data: { turbo_confirm: "本当に削除しますか？", turbo_stream: true }, class: "btn btn-error h-12 w-25 mr-5 md:w-42" %>
 
-              <div class="btn btn-accent h-12 w-25 md:w-42">
-                <%= link_to edit_milestone_path(@milestone), class: "w-full h-full flex justify-center items-center", data: { turbo_frame: "milestones_edit_modal"} do %>
-                  <p>
-                  編集
-                  </p>
-                <% end %>
-              </div>
-            </div>
-          <% end %>
+
+
+
         </div>
 
       </div>

--- a/app/views/milestones/_show_complete_page_modal_content.html.erb
+++ b/app/views/milestones/_show_complete_page_modal_content.html.erb
@@ -22,7 +22,7 @@
           <%= render "error_messages", resource: @milestone %>
 
           <!-- 編集フォーム -->
-          <%= form_for(@milestone, as: @milestone, url: complete_milestone_path(@milestone), html: { method: :patch, class: "w-full mt-10 p-2" }) do |f| %>
+          <%= form_for(@milestone, as: @milestone, url: complete_milestone_path(@milestone), data: { turbo_confirm: "これで完成させますか？" }, html: { method: :patch, class: "w-full mt-10 p-2" }) do |f| %>
 
             <label class="floating-label">
               <%= f.text_area :completed_comment,
@@ -46,12 +46,7 @@
               </div>
             </div>
 
-
             <% end %>
-
-
-
-
 
         </div>
 

--- a/app/views/milestones/_show_complete_page_modal_content.html.erb
+++ b/app/views/milestones/_show_complete_page_modal_content.html.erb
@@ -1,0 +1,109 @@
+<div class="modal-box max-h-[90vh]">
+  <p class="text-center pb-4">ESC or 下の(X)を押すと閉じます</p>
+  <div class="flex w-full items-center justify-center">
+    <div class="card z-10 flex h-2xl w-full justify-center bg-base-300 p-5 text-center md:w-2xl">
+      <div>
+
+        <!-- タスク詳細表示 -->
+        <div class="space-y-5">
+          <div class="flex items-center justify-center text-secondary">
+            <p class="text-xl">星座を完成させる</p>
+          </div>
+
+          <!-- マイルストーン -->
+          <div class="flex items-center justify-center text-xl">
+            <div class="mr-2">
+              <%= render "stars_icon", { width: 35, height: 35, color: @milestone.color } %>
+            </div>
+            <%= @milestone.title %>
+          </div>
+
+          <!-- タイトル -->
+          <div class="flex w-full items-center justify-center">
+            <div class="card w-full text-neutral">
+              <p class="card-title h-5 pl-2 text-sm text-primary">Title</p>
+              <div class="flex w-full items-center justify-center rounded-xl bg-primary p-3">
+                <%= @milestone.title %>
+              </div>
+            </div>
+          </div>
+
+
+          <!-- 期間 -->
+          <% if @milestone.start_date.present? || @milestone.end_date.present? %>
+            <div class="flex w-full justify-between px-5 text-neutral">
+              <div class="card flex h-full w-2/5 flex-col justify-center bg-primary p-2">
+                <div>
+                  <%= @milestone.start_date&.year %>年
+                </div>
+                <div class="w-full font-bold md:text-2xl">
+                  <%= to_short_date(@milestone.start_date) %>
+                </div>
+              </div>
+              <div class="flex w-1/5 items-center justify-center">
+                <p class="w-full text-5xl text-primary">~</p>
+              </div>
+              <div class="card flex h-full w-2/5 flex-col justify-center bg-primary p-2">
+                <%= @milestone.end_date&.year %>年<br>
+                <div class="w-full font-bold md:text-2xl">
+                  <%= to_short_date(@milestone.end_date) %>
+                </div>
+              </div>
+            </div>
+          <% else %>
+            <div class="flex w-full justify-center">
+              <div class="card w-full bg-primary p-10 text-neutral">
+                日付は設定されていません
+              </div>
+            </div>
+          <% end %>
+
+          <!-- 説明 -->
+          <div class="flex w-full items-center justify-center">
+            <div class="card w-full text-neutral">
+              <p class="card-title h-5 pl-2 text-sm text-primary">Description</p>
+              <div class="flex min-h-24 w-full items-center justify-center rounded-xl bg-primary p-3">
+                <%= @milestone.description.present? ? @milestone.description : "説明はありません" %>
+              </div>
+            </div>
+          </div>
+
+          <!-- 進捗状況 -->
+          <div class="flex w-full items-center justify-center">
+            <div class="card w-full text-neutral">
+              <p class="card-title h-5 pl-2 text-sm text-primary">Progress</p>
+              <div class="flex w-full items-center justify-center rounded-xl bg-primary p-3">
+                <%= @milestone.progress %>
+              </div>
+            </div>
+          </div>
+
+          <!-- アクションボタン -->
+          <% if current_user?(@milestone.user) %>
+            <div class="flex h-12 w-full mt-10 justify-center text-neutral">
+              <%= button_to "削除", milestone_path(@milestone), method: :delete, data: { turbo_confirm: "本当に削除しますか？", turbo_stream: true }, class: "btn btn-error h-12 w-25 mr-5 md:w-42" %>
+
+              <div class="btn btn-accent h-12 w-25 md:w-42">
+                <%= link_to edit_milestone_path(@milestone), class: "w-full h-full flex justify-center items-center", data: { turbo_frame: "milestones_edit_modal"} do %>
+                  <p>
+                  編集
+                  </p>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+
+      </div>
+    </div>
+  </div>
+  <div class="modal-action flex justify-center">
+    <form method="dialog">
+      <button class="btn btn-accent px-9">
+        <span class="material-symbols-outlined">
+          close
+        </span>
+      </button>
+    </form>
+  </div>
+</div>

--- a/app/views/milestones/complete.turbo_stream.erb
+++ b/app/views/milestones/complete.turbo_stream.erb
@@ -1,0 +1,18 @@
+<%= turbo_stream.replace "flash" do %>
+  <%= render "flash" %>
+<% end %>
+
+<% if @milestone_complete_success == true %>
+  <%= turbo_stream.replace "show_complete_page_modal" do %>
+    <%= render "milestones/completed_page", milestone: @milestone, completed_page_modal_open: @completed_page_modal_open %>
+  <% end %>
+
+  <%= turbo_stream.replace "milestone_#{@milestone.id}" do %>
+    <%= render "milestones/milestone", milestone: @milestone, completed: true %>
+  <% end %>
+
+<% else %>
+  <%= turbo_stream.replace "show_complete_page_modal" do %>
+    <%= render "milestones/show_complete_page_modal", milestone: @milestone, show_complete_page_modal_open: @show_complete_page_modal_open %>
+  <% end %>
+<% end %>

--- a/app/views/milestones/index.html.erb
+++ b/app/views/milestones/index.html.erb
@@ -55,4 +55,4 @@
   </div>
 
   <%= render "milestones/milestones_new_modal", milestone: @milestone %>
-  <%= turbo_frame_tag "milestones_complete_page_modal" %>
+  <%= turbo_frame_tag "show_complete_page_modal" %>

--- a/app/views/milestones/index.html.erb
+++ b/app/views/milestones/index.html.erb
@@ -55,3 +55,4 @@
   </div>
 
   <%= render "milestones/milestones_new_modal", milestone: @milestone %>
+  <%= turbo_frame_tag "milestones_complete_page_modal" %>

--- a/app/views/milestones/show_complete_page.html.erb
+++ b/app/views/milestones/show_complete_page.html.erb
@@ -1,11 +1,13 @@
-<%= turbo_frame_tag "milestones_complete_page_modal" do %>
+<%= turbo_frame_tag "show_complete_page_modal" do %>
   <div data-controller="show-modal">
     <div data-show-modal-target="modal_top">
       <dialog data-show-modal-target="task_modal" id="milestone_complete_modal" class="modal" <%= @milestone_complete_modal_open ? 'open' : ' ' %> >
 
-    <!-- まずはturbo_frame_tagを使ってmilestones/show_complete_pageでモーダルの部分を表示 -->
-    <!-- milestones#updateでturbo_stremasを使って、モーダルの部分をこのファイルに更新しています -->
-    <%= render "milestones/show_complete_page_modal_content", milestone: @milestone %>
+        <!-- まずはturbo_frame_tagを使ってmilestones/show_complete_pageでモーダルの部分を表示 -->
+        <!-- milestones#completeでturbo_stremasを使って、モーダルの部分を更新しています -->
+        <%= render "milestones/show_complete_page_modal_content", milestone: @milestone %>
 
-  </dialog>
+      </dialog>
+    </div>
+  </div>
 <% end %>

--- a/app/views/milestones/show_complete_page.html.erb
+++ b/app/views/milestones/show_complete_page.html.erb
@@ -4,7 +4,7 @@
       <dialog data-show-modal-target="task_modal" id="milestone_complete_modal" class="modal" <%= @milestone_complete_modal_open ? 'open' : ' ' %> >
 
         <!-- まずはturbo_frame_tagを使ってmilestones/show_complete_pageでモーダルの部分を表示 -->
-        <!-- milestones#completeでturbo_stremasを使って、モーダルの部分を更新しています -->
+        <!-- milestones#completeでturbo_streamsを使って、モーダルの部分を更新しています -->
         <%= render "milestones/show_complete_page_modal_content", milestone: @milestone %>
 
       </dialog>

--- a/app/views/milestones/show_complete_page.html.erb
+++ b/app/views/milestones/show_complete_page.html.erb
@@ -1,0 +1,11 @@
+<%= turbo_frame_tag "milestones_complete_page_modal" do %>
+  <div data-controller="show-modal">
+    <div data-show-modal-target="modal_top">
+      <dialog data-show-modal-target="task_modal" id="milestone_complete_modal" class="modal" <%= @milestone_complete_modal_open ? 'open' : ' ' %> >
+
+    <!-- まずはturbo_frame_tagを使ってmilestones/show_complete_pageでモーダルの部分を表示 -->
+    <!-- milestones#updateでturbo_stremasを使って、モーダルの部分をこのファイルに更新しています -->
+    <%= render "milestones/show_complete_page_modal_content", milestone: @milestone %>
+
+  </dialog>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,11 @@ Rails.application.routes.draw do
     patch "update_progress", on: :member
   end
 
-  resources :milestones
+  resources :milestones do
+    get "show_complete_page", on: :member
+    patch "complete", on: :member
+  end
+
   devise_for :users, controllers: {
     registrations: "users/registrations",
     sessions: "users/sessions",


### PR DESCRIPTION
<!-- github copilot レビューは日本語でお願いします -->
# 概要

<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->



# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイントです -->

- app
  - controllers
    - milestones_controller.rb
      - show_complete_pageメソッドと、completeメソッドを追加
        - show_complete_page：completed_commentを入力するためのモーダルをturbo_frameで表示する
        - complete：milestoneのprogressを"completed"にし、星座とランダムに紐づけ、show_complete_page_modalで入力したcompleted_commentを設定して保存する。保存に成功した場合、show_complet_page_modalを完成した星座を表示するモーダルに置換する。
      - ストロングパラメータにcompleted_commentを追加

  - models
    - milestone.rb
      - バリデーションを追加
```
validates :progress, presence: true
validates :color, presence: true
validates :completed_comment, length: { maximum: 50 }, allow_blank: true
validates :is_public, inclusion: { in: [true, false] }
validates :is_on_chart, inclusion: { in: [true, false] }
```

  - views/milestones
    - _completed_page.html.erb
      - 完成した星座を表示するモーダル
    - _milestone.html.erb
      - milestonesに表示するmilestoneのためのパーシャル
    - _milestones.html.erb
      - turbostremaに対応するため_milestoneに切り離し
    - _show_complete_page_modal.html.erb
      - milestones#complete後、turbo_streamで置換するためのパーシャル
    - _show_complete_page_modal_content.html.erb
      - milestones/show_complete_pageと、_show_complete_page_modalの内容共通部分のパーシャル
    - complete.turbo_stream.erb
      - milestones#complete後に実行するturbo_stream用のファイル
    - index.html.erb
      - milestones/show_complete_pageを置換するためのturbo_frame_tagを追加
    - show_complete_page.html.erb
      - milestones#show_complete_pageでturbo_frameを用いて置換するためのビュー

  - config
    - routes.rb
      - milestones#show_complete_pageと#completeへのルーティングを追加
```
  resources :milestones do
    get "show_complete_page", on: :member
    patch "complete", on: :member
  end
```
    - .rubocop.yml
      - Metrics/ClassLength: Max: 150を追記し、milestonesコントローラーが長くなっていることを許しました。


## スクリーンショット
![image](https://github.com/user-attachments/assets/fa36d7e1-478e-459f-a501-1244d3f160b2)
![image](https://github.com/user-attachments/assets/2a42ac42-2974-4c63-ae9e-ed8704e3b51a)

<!-- github copilot レビューは日本語でお願いします -->
