### PR TITLE
tasksとmilestonesを分けて確認できるようにしました closes #40

### DIFF
--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -1,6 +1,5 @@
 class LineBotController < ApplicationController
   protect_from_forgery except: [:callback]
-
   def callback
     body = request.body.read
     signature = request.env["HTTP_X_LINE_SIGNATURE"]
@@ -11,7 +10,9 @@ class LineBotController < ApplicationController
 
     events = client.parse_events_from(body)
     events.each do |event|
-      client.reply_message(event["replyToken"], message(event))
+      setup(event)
+      reply_message = reply
+      client.reply_message(event["replyToken"], reply_message)
     end
   end
 
@@ -24,135 +25,56 @@ class LineBotController < ApplicationController
     end
   end
 
-  def message(event)
-    case event
+  def reply
+    case @event
     when Line::Bot::Event::Message
-      case event.type
+      case @event.type
       when Line::Bot::Event::MessageType::Text
-        handle_message_event(event)
+        handle_message_event
       end
     end
   end
 
-  def handle_message_event(event)
-    case event.message["text"]
-    when "タスクを確認"
-      {
-        type: "text",
-        text: get_all_milestones_and_tasks(event)
-      }
+  def handle_message_event
+    case @event.message["text"]
+    when "タスク確認"
+      LineBot::MessageBuilder.text(@task_presenter.tasks_list)
+    when "星座確認"
+      LineBot::MessageBuilder.text(@milestone_presenter.milestones_list)
+    when "両方確認"
+      LineBot::MessageBuilder.text(
+        "#{@milestone_presenter.milestones_list}\n\n----------\n\n#{@task_presenter.tasks_list}"
+      )
+    when "星座の名前で確認"
+      Rails.cache.write("user_#{@user_id}_step", "tasks_for_milestone", expires_in: 10.minutes)
+
+      LineBot::MessageBuilder.text(
+        "続いて、星座のタイトルを送信してください。\n\n↓星座のタイトル一覧↓\n#{@milestone_presenter.milestones_title_list}"
+      )
     else
-      {
-        type: "text",
-        text: "タスクを確認するには「タスクを確認」と送信してください。"
-      }
+      handle_other_message
     end
   end
 
-  # 星座とタスクの両方のリストを取得して結合する
-  def get_all_milestones_and_tasks(event)
-    user = get_user(event)
-
-    if user.nil?
-      "ユーザーIDが取得できませんでした。"
+  def handle_other_message
+    if Rails.cache.read("user_#{@user_id}_step") == "tasks_for_milestone"
+      handle_milestone_selection
     else
-      "#{get_milestones_list(event)} \n\n ---------- \n\n #{get_tasks_list(event)}"
+      LineBot::MessageBuilder.text("メニューから選択してください")
     end
   end
 
-  # ユーザーを取得するメソッド
-  def get_user(event)
-    user_id = event["source"]["userId"]
-    user = User.find_by(uid: user_id)
-
-    if user.nil?
-      nil
-    else
-      user
-    end
+  def handle_milestone_selection
+    Rails.cache.delete("user_#{@user_id}_step")
+    milestone_title = @event.message["text"]
+    LineBot::MessageBuilder.text(@task_presenter.tasks_for_milestone(milestone_title))
   end
 
-  # 星座のリストを取得するメソッド
-  def get_milestones_list(event)
-    user = get_user(event)
-    milestones = user.milestones.order(:start_date).where.not(progress: "completed")
-
-    if user.nil?
-      "ユーザーIDが取得できませんでした。"
-    elsif milestones.empty?
-      "星座はまだありません！"
-    else
-      messages = milestones.map do |milestone|
-        is_first = milestone == milestones.first
-        start_date = to_short_date(milestone.start_date)
-        end_date = to_short_date(milestone.end_date)
-        tasks_count = milestone.tasks.count
-
-        "#{is_first ? '' : "\n"}🌟：#{milestone.title}\
-        \n   📝：#{tasks_count}つ\
-        \n   #{start_date} ~ #{end_date}"
-      end
-      messages.join("\n")
-    end
-  end
-
-  # タスクのリストを取得するメソッド
-  def get_tasks_list(event)
-    user = get_user(event)
-    tasks = user.tasks.order(:start_date).reject { |t| t&.milestone_completed? }
-
-    if user.nil?
-      "ユーザーIDが取得できませんでした。"
-    elsif tasks.empty?
-      "タスクはありません！"
-    else
-      tasks_message(tasks)
-    end
-  end
-
-  def tasks_message(tasks)
-    tasks.map do |task|
-      is_first = task == tasks.first
-      start_date = to_short_date(task.start_date)
-      end_date = to_short_date(task.end_date)
-      task_milestone_title = task.milestone&.title || "---"
-      progress = get_progress(task)
-
-      "#{is_first ? '' : "\n"}📝：#{task.title} - #{progress}\
-      \n   🌟：#{task_milestone_title}\
-      \n    #{start_date} ~ #{end_date}"
-    end.join("\n")
-  end
-
-  # タスクの進捗を取得するメソッド
-  def get_progress(task)
-    case task.progress
-    when "not_started"
-      "🍵 未着手"
-    when "in_progress"
-      "👉 進行中"
-    when "completed"
-      "✅ 完了"
-    else
-      "❓不明な進捗"
-    end
-  end
-
-  # 曜日を取得するメソッド
-  def day_of_week(date)
-    return if date.nil?
-
-    day_name_ja = %w[日 月 火 水 木 金 土]
-
-    d = date.to_date.wday
-
-    day_name_ja[d]
-  end
-
-  # 日付を短縮形式で表示するメソッド
-  def to_short_date(date)
-    return if date.nil?
-
-    "#{date.mon}/#{date.mday} (#{day_of_week(date)})"
+  def setup(event)
+    @event = event
+    @user_id = event["source"]["userId"]
+    @user = User.find_by(uid: @user_id)
+    @task_presenter = LineBot::TaskPresenter.new(@user)
+    @milestone_presenter = LineBot::MilestonePresenter.new(@user)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,4 +18,18 @@ module ApplicationHelper
 
     "#{date.mon}/#{date.mday} (#{day_of_week(date)})"
   end
+
+  # タスクの進捗を取得するメソッド
+  def get_progress_message(task)
+    case task.progress
+    when "not_started"
+      "🍵 未着手"
+    when "in_progress"
+      "👉 進行中"
+    when "completed"
+      "✅ 完了"
+    else
+      "❓不明な進捗"
+    end
+  end
 end

--- a/app/services/line_bot/message_builder.rb
+++ b/app/services/line_bot/message_builder.rb
@@ -20,7 +20,7 @@ module LineBot
       tasks = milestone.tasks.order(:start_date)
       tasks_info = tasks.present? ? tasks_message(tasks, is_show_milestone: false) : "タスクはありません"
 
-      "#{milestone_info}\n\n   #{tasks_info}"
+      "#{milestone_info}\n\n#{tasks_info}"
     end
 
     # taskの情報表示部分を生成する

--- a/app/services/line_bot/message_builder.rb
+++ b/app/services/line_bot/message_builder.rb
@@ -91,7 +91,7 @@ module LineBot
       when "completed"
         "✅ 完了"
       else
-        "状態不明"
+        "❓状態不明"
       end
     end
 

--- a/app/services/line_bot/message_builder.rb
+++ b/app/services/line_bot/message_builder.rb
@@ -1,0 +1,104 @@
+module LineBot
+  class MessageBuilder
+    # メッセージの形を形成するクラス
+
+    def self.text(message)
+      { type: "text", text: message }
+    end
+
+    # tasksのメッセージを生成する
+    def self.tasks_message(tasks, is_show_milestone: true)
+      tasks.map.with_index do |task, index|
+        is_first = index.zero?
+        tasks_info(task, is_first: is_first, is_show_milestone: is_show_milestone)
+      end.join("\n")
+    end
+
+    # milestoneと、それのtasksのメッセージを生成する
+    def self.milestone_with_tasks_message(milestone)
+      milestone_info = milestone_info(milestone, is_first: true)
+      tasks = milestone.tasks.order(:start_date)
+      tasks_info = tasks.present? ? tasks_message(tasks, is_show_milestone: false) : "タスクはありません"
+
+      "#{milestone_info}\n\n   #{tasks_info}"
+    end
+
+    # taskの情報表示部分を生成する
+    def self.tasks_info(task, is_first: false, is_show_milestone: true)
+      start_date = task.start_date.present? ? to_short_date(task.start_date) : ""
+      end_date = task.end_date.present? ? to_short_date(task.end_date) : ""
+      task_milestone_title = task.milestone&.title || "---"
+      progress = get_progress_message(task)
+
+      "#{is_first ? '' : "\n"}📝：#{task.title} - #{progress}\
+      #{"\n   🌟：#{task_milestone_title}" if is_show_milestone}\
+      \n   #{date_range(start_date, end_date)}"
+    end
+
+    # milestonesのメッセージを生成する
+    def self.milestones_message(milestones)
+      milestones.map do |milestone|
+        is_first = milestone == milestones.first
+        milestone_info(milestone, is_first: is_first)
+      end.join("\n")
+    end
+
+    # milestonesのタイトルのみのメッセージを生成する
+    def self.milestones_title_message(milestones)
+      milestones.map do |milestone|
+        is_first = milestone == milestones.first
+        "#{is_first ? "\n" : ''}🌟：#{milestone.title}"
+      end.join("\n")
+    end
+
+    # milestoneの情報表示部分を生成する
+    def self.milestone_info(milestone, is_first: false)
+      start_date = milestone.start_date.present? ? to_short_date(milestone.start_date) : "未設定"
+      end_date = milestone.end_date.present? ? to_short_date(milestone.end_date) : "未設定"
+      tasks_count = milestone.tasks.count
+      completed_tasks_count = milestone.tasks.completed.count
+      completed_tasks_percentage = milestone.completed_tasks_percentage
+
+      "#{is_first ? '' : "\n"}🌟：#{milestone.title}\
+      \n   📝：#{tasks_count}(完成：#{completed_tasks_count})\
+      \n   🏁：#{completed_tasks_percentage}%\
+      \n   #{date_range(start_date, end_date)}"
+    end
+
+    def self.to_short_date(date)
+      return if date.nil?
+
+      "#{date.mon}/#{date.mday} (#{day_of_week(date)})"
+    end
+
+    # 日付の曜日を日本語で取得する
+    def self.day_of_week(date)
+      return if date.nil?
+
+      day_name_ja = %w[日 月 火 水 木 金 土]
+
+      d = date.to_date.wday
+
+      day_name_ja[d]
+    end
+
+    def self.get_progress_message(task)
+      case task.progress
+      when "not_started"
+        "🍵 未着手"
+      when "in_progress"
+        "👉 進行中"
+      when "completed"
+        "✅ 完了"
+      else
+        "状態不明"
+      end
+    end
+
+    def self.date_range(start_date, end_date)
+      "#{start_date} ~ #{end_date}"
+    end
+
+    private_class_method :milestone_info, :date_range, :tasks_info
+  end
+end

--- a/app/services/line_bot/milestone_presenter.rb
+++ b/app/services/line_bot/milestone_presenter.rb
@@ -1,0 +1,31 @@
+module LineBot
+  class MilestonePresenter
+    def initialize(user)
+      @user = user
+    end
+
+    def milestones_list
+      return "ユーザーが見つかりません" unless @user
+
+      milestones = active_milestones
+      return "星座はまだありません！" if milestones.empty?
+
+      MessageBuilder.milestones_message(milestones)
+    end
+
+    def milestones_title_list
+      return "ユーザーが見つかりません" unless @user
+
+      milestones = active_milestones
+      return "星座はまだありません！" if milestones.empty?
+
+      MessageBuilder.milestones_title_message(milestones)
+    end
+
+    private
+
+    def active_milestones
+      @user.milestones.order(:start_date).where.not(progress: "completed")
+    end
+  end
+end

--- a/app/services/line_bot/task_presenter.rb
+++ b/app/services/line_bot/task_presenter.rb
@@ -5,11 +5,11 @@ module LineBot
     end
 
     def tasks_list
-      tasks = @user.tasks.order(:start_date).reject { |t| t&.milestone_completed? }
+      return "ユーザーIDが取得できませんでした。" if @user.nil?
 
-      if @user.nil?
-        "ユーザーIDが取得できませんでした。"
-      elsif tasks.empty?
+      tasks = @user.tasks.order(:start_date).reject { |t| t.milestone.present? && t.milestone.completed? }
+
+      if tasks.empty?
         "タスクはありません！"
       else
         MessageBuilder.tasks_message(tasks)

--- a/app/services/line_bot/task_presenter.rb
+++ b/app/services/line_bot/task_presenter.rb
@@ -1,0 +1,29 @@
+module LineBot
+  class TaskPresenter
+    def initialize(user)
+      @user = user
+    end
+
+    def tasks_list
+      tasks = @user.tasks.order(:start_date).reject { |t| t&.milestone_completed? }
+
+      if @user.nil?
+        "ユーザーIDが取得できませんでした。"
+      elsif tasks.empty?
+        "タスクはありません！"
+      else
+        MessageBuilder.tasks_message(tasks)
+      end
+    end
+
+    def tasks_for_milestone(milestone_title)
+      milestone = @user.milestones.find_by(title: milestone_title)
+
+      if milestone
+        MessageBuilder.milestone_with_tasks_message(milestone)
+      else
+        "その星座は見つかりませんでした。"
+      end
+    end
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,8 +1,7 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
-  config.hosts << "4e3b-123-254-11-172.ngrok-free.app"
-  # Settings specified here will take precedence over those in config/application.rb.
+  config.hosts << "0833-123-254-11-172.ngrok-free.app"  # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development


### PR DESCRIPTION
<!-- github copilot レビューは日本語でお願いします -->
# 概要

<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->

LINEbotから、tasks, milestones, milestonesの名前を指定してtasks, 両方を一度に確認する項目を実装


# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイントです -->

- app
  - controllers
    - line_bot_controller.rb 38, 116
      - 送られてきたテキストによって分岐するhandler部分を覗いて、サービスクラスに切り出しました

  - services/line_bot
    - message_builder.rb 104, 0
      - 送信するメッセージを形成する部分のロジックを配置
    - milestone_presenter.rb 31, 0
      - milestoneのメッセージ生成までの分岐やガード節のロジックを実装する
    - task_presenter.rb 29, 0
      - tasksのメッセージ生成までの分岐やガード節のロジックを実装する

サービスクラスの実装を行いました。
linebot特有の挙動なのでconcernではなくサービスクラスで実装を行いました。

## スクリーンショット
![Screenshot_20250427-152015](https://github.com/user-attachments/assets/64cf35d0-dbdc-4e89-b084-10902cb1d7f9)

<!-- Command + Shift + Control + 4 でスクリーンショットして Command + V でここに貼り付けるのが楽。以下のテーブルは必要に応じて使ってください -->


<!-- github copilot レビューは日本語でお願いします -->

