### PR TITLE
fix: user/showに星座完成モーダル置換用のturbo_frame_tagを設置

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -107,4 +107,5 @@
 <% if current_user?(@user) %>
   <!-- モーダル -->
   <%= render 'devise/registrations/edit_form_modal' %>
+  <%= turbo_frame_tag "show_complete_page_modal" %>
 <% end %>


### PR DESCRIPTION
user/showで星座完成を行おうとすると、モーダルではなくページ遷移していた不具合を修正しました。