### PR TITLE
add: LINE認証時に、tasksもmilestonesもemptyの場合、サンプルタスクを生成するようにしました

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -25,6 +25,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       end
       @profile.set_values(@omniauth)
       sign_in(:user, @profile)
+      UserRegistration::MakeTasksMilestones.create_tasks_and_milestones(@profile) if @profile.tasks.empty? && @profile.milestones.empty?
     end
     # ログイン後のflash messageとリダイレクト先を設定
     flash[:notice] = "ログインしました"

--- a/app/services/user_registration/make_tasks_milestones.rb
+++ b/app/services/user_registration/make_tasks_milestones.rb
@@ -50,7 +50,7 @@ module UserRegistration
         星座一覧から完成ボタンを押して、星座を完成させてみてください",
         progress: "in_progress",
         color: "#5E6BFF",
-        start_date: Date.today - 1.week,
+        start_date: Date.today - 3.day,
         end_date: Date.today + 3.week
       )
       user.tasks.create!(


### PR DESCRIPTION
LINE認証で登録した場合、サンプルタスクが生成されなかったので、tasksとmilestonesの数から判定してサンプルタスクを生成する形にしました。
このままだと、全てのタスクと星座を削除したユーザーにも生成されてしまいますが、あまり想定されないことから、このまま進めます。

また、サンプルmilestone同士の見た目にさ差をつけるために、開始日を少しずらしました。
