### PR TITLE
fix: チャートの日付表示列が画面幅をこえて横スクロールする際に追随しなくなっていた問題を修正

### DIFF
--- a/app/views/gantt_chart/_chart_layout.html.erb
+++ b/app/views/gantt_chart/_chart_layout.html.erb
@@ -1,5 +1,5 @@
   <div id="gantt_chart" class="h-[90vh] overflow-auto border rounded-lg shadow-sm border-base-300 bg-base-300/50">
-    <div class="flex min-w-full w-max">
+    <div class="flex min-w-full" style="width: max(<%= chart_total_width %>px, 100%);">
 
       <!-- 日付列 -->
       <div class="sticky left-0 w-[60px] border-r border-gray-700 bg-gray-800 relative z-60">


### PR DESCRIPTION
チャートの日付表示列が、横にスクロールした際に一定を超えると追随せず流れてしまう問題を修正しました。
日付表示列の親要素が画面いっぱいまでしか広がっておらず、そこを超えた際に起こっていたので、こちらにもstyleでchart_total_widthと100%のうち大きな方のサイズの横幅になるようにしました。