### PR TITLE
fix:重ねる際に、borderを付与していた記述を削除

### DIFF
--- a/app/controllers/concerns/ogp_creator.rb
+++ b/app/controllers/concerns/ogp_creator.rb
@@ -28,8 +28,6 @@ class OgpCreator
       base_image = base_image.composite(rounded_thumb) do |c|
         c.compose "Over"
         c.geometry ROUND_IMAGE_POSITION
-        c.border "5"
-        c.bordercolor "transparent"
       end
     end
 


### PR DESCRIPTION
image_nameがある際だけ、ogp_bgにボーダーを設定していたので、どちらも設定しないように修正しました。