### PR TITLE
ホームやそのほかのデザイン周りを微調整しました。 closes #157

### DIFF
--- a/app/views/application/_menu_bar.html.erb
+++ b/app/views/application/_menu_bar.html.erb
@@ -1,8 +1,8 @@
 
 <div class="z-100 dock dock-md md:dock-lg bg-base-300">
 
-  <div class="dropdown dropdown-top">
-    <button tabindex="0" class="flex flex-col w-full h-full items-center justify-center">
+  <div class="dropdown dropdown-top hover:opacity-100">
+    <button tabindex="0" class="flex flex-col w-full h-full items-center justify-center hover:opacity-80">
       <span class="material-symbols-outlined">menu</span>
       <span class="dock-label">Menu</span>
     </button>

--- a/app/views/application/_title_header.html.erb
+++ b/app/views/application/_title_header.html.erb
@@ -1,4 +1,6 @@
-<%= image_tag 'mikaduki.png', class: 'absolute top-5 left-5 z-0 h-[50px] w-[50px]' %>
+<%= link_to root_path do %>
+  <%= image_tag 'mikaduki.png', class: 'absolute top-5 left-5 z-0 h-[50px] w-[50px]' %>
+<% end %>
 <div class="p-10 text-4xl flex items-center justify-center">
   <%= title %>
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -9,7 +9,7 @@
       <!-- ロゴ -->
       <div class="flex justify-center mx-auto">
         <%= link_to root_path do %>
-          <%= image_tag "mikaduki.png", width: "90" %>
+          <%= image_tag 'icon-512x512.png', width: "90" %>
         <% end %>
       </div>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -9,7 +9,7 @@
       <!-- ロゴ -->
       <div class="flex justify-center mx-auto">
         <%= link_to root_path do %>
-          <%= image_tag "mikaduki.png", width: "90" %>
+          <%= image_tag 'icon-512x512.png', width: "90" %>
         <% end %>
       </div>
 

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,15 +1,22 @@
 <%= render "flash" %>
 <div class="h-full w-full">
-  <%= image_tag 'mikaduki.png', class: 'absolute left-5 top-5 z-0 h-[50px] w-[50px]' %>
 
-  <div class="pt-50 flex max-sm:w-full flex-col items-center stats intersect:motion-ease-spring-bouncier intersect:motion-preset-slide-down intersect-once">
-    <div class="mb-20 text-6xl xl:text-8xl">
-      <%= image_tag 'mikaduki.png', class: 'inline-block h-[200px] w-[200px]' %>
-      <p class="text-center">星にタスクを</p>
+  <div class="h-[94vh] flex items-center justify-center max-sm:w-full intersect:motion-ease-spring-bouncier intersect:motion-preset-slide-down intersect-once">
+    <div class="flex flex-col items-center">
+      <%= image_tag 'icon-512x512.png', class: 'mb-5 h-20 w-20 md:h-30 md:w-30' %>
+      <p class="text-5xl md:text-6xl text-center [writing-mode:vertical-rl] [text-orientation:upright]">星にタスクを</p>
     </div>
   </div>
 
-  <div class="mb-20 animate-fade-in text-center text-xl xl:text-2xl">
+  <!-- スクロールの矢印 -->
+  <div class="flex justify-center">
+    scroll
+  </div>
+  <div class="flex justify-center mb-8">
+    <%= image_tag 'bar.png', class: 'h-[30px] w-[1px] animate-scroll' %>
+  </div>
+
+  <div class="mb-20 animate-fade-in text-center text-xl xl:text-2xl intersect:animate-fade-in intersect-once">
     今日したことを星で繋いで、<br>
     終わったタスクを星座にかえて。
 
@@ -18,14 +25,6 @@
   <!-- ボタン -->
   <div class="intersect:animate-fade-in intersect-once mb-8">
     <%= render 'auth_buttons' %>
-  </div>
-
-  <!-- スクロールの矢印 -->
-  <div class="flex justify-center">
-    scroll
-  </div>
-  <div class="flex justify-center">
-    <%= image_tag 'bar.png', class: 'h-[30px] w-[1px] animate-scroll' %>
   </div>
 
   <!-- 説明部分 -->


### PR DESCRIPTION
<!-- github copilot レビューは日本語でお願いします -->
# 概要

<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->

homeとsessions/new, registrations/newのデザイン変更しました。
ヘッダーの三日月をroot_pathへのリンクにしました。
メニューバーのドロップアップメニューがホバーで薄くなる問題を修正しました。


# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイントです -->

- app/views
  - application
    - _menu_bar.html.erb 2, 2
      - メニューのドロップアップ部分がhoverで薄くなる問題を修正
    - _title_header.html.erb 3, 1
      - 三日月の画像部分をroot_pathへのリンクに変更

  - devise
    - registrations
      - new.html.erb 1, 1
        - 三日月の画像を、アイコンの画像に
    - sessions
      - new.html.erb 1, 1
        - 三日月の画像を、アイコンの画像に
  - static_pages
    - home.html.erb 13, 14
      - タイトル部分のデザインを変更し、下に連なるいくつかの要素の順番を変更。

## スクリーンショット

<!-- Command + Shift + Control + 4 でスクリーンショットして Command + V でここに貼り付けるのが楽。以下のテーブルは必要に応じて使ってください -->
![image](https://github.com/user-attachments/assets/072810e8-c6c4-461e-9a5a-e9da4cc73004)
![image](https://github.com/user-attachments/assets/7c3935d3-63d1-4643-91a8-389eba71a00a)


<!-- github copilot レビューは日本語でお願いします -->
