### PR TITLE
tasksの詳細を表示する際に、turbo_frameの置換のディレイがあったので、遅延読み込みで事前にモーダルを読み込むように変更しました。

### DIFF
--- a/app/views/gantt_chart/_task_chart.html.erb
+++ b/app/views/gantt_chart/_task_chart.html.erb
@@ -37,28 +37,30 @@
         %>
 
         <!-- heightの-5は上下につける〇の要素のサイズ分 -->
-        <%= link_to task_path(task), id: "task_chart_#{task.id}", class: "absolute flex flex-col items-center cursor-pointer",
-          style: "top: #{task_top + margin_top}px;
-          height: #{task_height - (margin_top * 2) - 5}px;
-          left: #{task_left}px",
-          data: {turbo_frame: "tasks_show_modal"} do %>
-
-            <!-- タスク名 -->
-            <div class="absolute left-8 top-2 text-start [writing-mode:vertical-rl] ">
-              <div class="absolute left-[-14px] w-4 h-4 bg-base-200" style="clip-path: polygon(100% 0, 0 0, 100% 100%);"></div>
-              <div style="height: <%= task_title_height %>px">
-                <%= task.title.truncate(15, omission: '...') %>
-              </div>
+        <button 
+          id="task_chart_<%= task.id %>"
+          class="absolute flex flex-col items-center cursor-pointer"
+          onclick="tasks_show_modal_<%=task.id%>_target.showModal()"
+          style="top: <%= task_top + margin_top %>px;
+          height: <%= task_height - (margin_top * 2) - 5 %>px;
+          left: <%= task_left %>px"
+          >
+          <!-- タスク名 -->
+          <div class="absolute left-8 top-2 text-start [writing-mode:vertical-rl] ">
+            <div class="absolute left-[-14px] w-4 h-4 bg-base-200" style="clip-path: polygon(100% 0, 0 0, 100% 100%);"></div>
+            <div style="height: <%= task_title_height %>px">
+              <%= task.title.truncate(15, omission: '...') %>
             </div>
+          </div>
 
-            <!-- 開始点の円 -->
-            <div class="z-40 <%= task.in_progress? ? "size-4 relative top-1 mask mask-triangle-2" : "size-4 rounded-full" %>" style="background-color: <%= task.completed? ? "#{milestone_color}4d" : milestone_color %>;"></div>
+          <!-- 開始点の円 -->
+          <div class="z-40 <%= task.in_progress? ? "size-4 relative top-1 mask mask-triangle-2" : "size-4 rounded-full" %>" style="background-color: <%= task.completed? ? "#{milestone_color}4d" : milestone_color %>;"></div>
 
-            <% if task.start_date && task.end_date %>
-              <!-- 線 -->
-              <div class="w-1 flex-grow z-40" style="background-color: <%= task.completed? ? "#{milestone_color}4d" : milestone_color %>;"></div>
+          <% if task.start_date && task.end_date %>
+            <!-- 線 -->
+            <div class="w-1 flex-grow z-40" style="background-color: <%= task.completed? ? "#{milestone_color}4d" : milestone_color %>;"></div>
 
-              <!-- 終了点の円 -->
-              <div class="z-40 <%= task.in_progress? ? "size-4 relative -top-1 mask mask-triangle" : "size-4 rounded-full" %>" style="background-color: <%= task.completed? ? "#{milestone_color}4d" : milestone_color %>;"></div>
-            <% end %>
+            <!-- 終了点の円 -->
+            <div class="z-40 <%= task.in_progress? ? "size-4 relative -top-1 mask mask-triangle" : "size-4 rounded-full" %>" style="background-color: <%= task.completed? ? "#{milestone_color}4d" : milestone_color %>;"></div>
           <% end %>
+        </button>

--- a/app/views/gantt_chart/show.html.erb
+++ b/app/views/gantt_chart/show.html.erb
@@ -12,9 +12,13 @@
 <div class="mt-10">
   <%= render "menu_bar" %>
 </div>
-<%= turbo_frame_tag "tasks_show_modal" %>
 <%= turbo_frame_tag "tasks_edit_modal" %>
 <%= turbo_frame_tag "milestone_show_modal" %>
+<%= @milestones.map do |milestone| %>
+  <%= milestone.tasks.map do |task| %>
+    <%= turbo_frame_tag "tasks_show_modal_#{task.id}", src: task_path(task) %>
+  <% end %>
+<% end %>
 
 <script>
   // ページ遷移時にidがtodayの要素をスクロールして表示

--- a/app/views/gantt_chart/show.html.erb
+++ b/app/views/gantt_chart/show.html.erb
@@ -14,8 +14,8 @@
 </div>
 <%= turbo_frame_tag "tasks_edit_modal" %>
 <%= turbo_frame_tag "milestone_show_modal" %>
-<%= @milestones.map do |milestone| %>
-  <%= milestone.tasks.map do |task| %>
+<%= @milestones.each do |milestone| %>
+  <%= milestone.tasks.each do |task| %>
     <%= turbo_frame_tag "tasks_show_modal_#{task.id}", src: task_path(task) %>
   <% end %>
 <% end %>

--- a/app/views/milestones/show.html.erb
+++ b/app/views/milestones/show.html.erb
@@ -225,8 +225,11 @@
   <%= turbo_frame_tag "tasks_new_modal" %>
 <% end %>
 
-<%= turbo_frame_tag "tasks_show_modal" %>
 <%= turbo_frame_tag "milestone_show_modal" %>
+<% @milestone_tasks.each do |task| %>
+  <%= turbo_frame_tag "tasks_show_modal_#{task.id}", src: task_path(task)%>
+<% end %>
+
 
 <script>
   document.addEventListener("turbo:load", function() {

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -1,7 +1,11 @@
 <div id="task_<%=task.id%>" class="card mb-4 w-full p-4 bg-base-300/40 shadow-xl/10">
 
   <div class="flex w-full items-center text-left">
-    <%= link_to task_path(task), class: "w-full p-1 rounded-xl hover:bg-base-300/30", data: { turbo_frame: "tasks_show_modal"} do %>
+
+    <button 
+      class="w-full p-1 rounded-xl hover:bg-base-300/30 hover:cursor-pointer text-start"
+      onclick="tasks_show_modal_<%=task.id%>_target.showModal()
+      ">
       <!-- タイトル, 日付, マーク -->
       <div class="flex w-full">
         <div class="flex items-center">
@@ -24,8 +28,7 @@
         <% end %>
       </div>
 
-
-    <% end %>
+    </button>
 
       <!-- progressボタン -->
       <% unless task.milestone_completed? %>
@@ -35,3 +38,4 @@
 
 </div>
 
+<%= turbo_frame_tag "tasks_show_modal_#{task.id}", src: task_path(task)%>

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -4,8 +4,8 @@
 
     <button 
       class="w-full p-1 rounded-xl hover:bg-base-300/30 hover:cursor-pointer text-start"
-      onclick="tasks_show_modal_<%=task.id%>_target.showModal()
-      ">
+      onclick="tasks_show_modal_<%=task.id%>_target.showModal()"
+      >
       <!-- タイトル, 日付, マーク -->
       <div class="flex w-full">
         <div class="flex items-center">
@@ -37,5 +37,3 @@
   </div>
 
 </div>
-
-<%= turbo_frame_tag "tasks_show_modal_#{task.id}", src: task_path(task)%>

--- a/app/views/tasks/_tasks_show_modal.html.erb
+++ b/app/views/tasks/_tasks_show_modal.html.erb
@@ -1,8 +1,8 @@
-<%= turbo_frame_tag "tasks_show_modal" do %>
-      <dialog id="tasks_show_modal" class="modal" <%= tasks_show_modal_open ? 'open' : ' ' %> >
+<%= turbo_frame_tag "tasks_show_modal_#{@task.id}" do %>
+  <dialog id="tasks_show_modal_<%= @task.id %>_target" class="modal" <%= tasks_show_modal_open ? 'open' : ' ' %> >
 
-        <!-- まずはturbo_frame_tagを使ってtasks/showでモーダルの部分を表示 -->
-        <!-- tasks#updateでturbo_stremasを使って、モーダルの部分をこのファイルに更新しています -->
+        <%# まずはturbo_frame_tagを使ってtasks/showでモーダルの部分を表示 %>
+        <%# tasks#updateでturbo_stremasを使って、モーダルの部分をこのファイルに更新しています %>
         <%= render "tasks/tasks_show_modal_content", task: @task %>
 
         <form method="dialog" class="modal-backdrop">

--- a/app/views/tasks/_tasks_show_modal_content.html.erb
+++ b/app/views/tasks/_tasks_show_modal_content.html.erb
@@ -1,4 +1,4 @@
-<div class="modal-box max-h-[90vh]">
+<div class="modal-box max-h-[90vh] text-sm">
   <p class="text-center pb-4">ESC or 画面外を押すと閉じます</p>
   <div class="flex w-full items-center justify-center">
     <div class="card z-10 flex h-2xl w-full justify-center bg-base-300 p-5 text-center md:w-2xl">
@@ -34,7 +34,7 @@
           <div class="flex w-full items-center justify-center">
             <div class="card w-full text-neutral">
               <p class="card-title h-5 pl-2 text-sm text-primary">Title</p>
-              <div class="flex w-full items-center justify-center rounded-xl bg-primary p-3">
+              <div class="flex w-full items-center justify-center rounded-xl text-xl bg-primary p-3">
                 <%= @task.title %>
               </div>
             </div>

--- a/app/views/tasks/create.turbo_stream.erb
+++ b/app/views/tasks/create.turbo_stream.erb
@@ -11,6 +11,10 @@
       <%= render "tasks/task", task: @task %>
     <% end %>
 
+    <%= turbo_stream.append "tasks_content" do %>
+      <%= turbo_frame_tag "tasks_show_modal_#{@task.id}", src: task_path(@task)%>
+    <% end %>
+
   <% else %>
     <%= turbo_stream.replace "tasks_new_modal" do %>
       <%= render "tasks_new_modal", task: @task, milestones: @milestones, tasks_edit_modal_open: @tasks_edit_modal_open %>

--- a/app/views/tasks/destroy.turbo_stream.erb
+++ b/app/views/tasks/destroy.turbo_stream.erb
@@ -4,9 +4,7 @@
     <%= render "flash" %>
   <% end %>
 
-  <%= turbo_stream.replace "tasks_show_modal" do %>
-    <%= turbo_frame_tag "tasks_show_modal" %>
-  <% end %>
+  <%= turbo_stream.remove "tasks_show_modal_#{@task.id}" %>
 
   <% if @task_milestone && @task.milestone.is_on_chart == true %>
     <%= turbo_stream.replace "chart_#{@task_milestone.id}" do %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -47,6 +47,13 @@
     <%= render "menu_bar" %>
   </div>
   <%= turbo_frame_tag "tasks_edit_modal" %>
-  <%= turbo_frame_tag "tasks_show_modal" %>
   <%= turbo_frame_tag "tasks_new_modal" %>
 
+  <% @not_completed_tasks.each do |task| %>
+    <%= turbo_frame_tag "tasks_show_modal_#{task.id}", src: task_path(task)%>
+  <% end %>
+  <% @completed_tasks.each do |task| %>
+    <%= turbo_frame_tag "tasks_show_modal_#{task.id}", src: task_path(task)%>
+  <% end %>
+
+  <% Fish.swim %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -55,5 +55,3 @@
   <% @completed_tasks.each do |task| %>
     <%= turbo_frame_tag "tasks_show_modal_#{task.id}", src: task_path(task)%>
   <% end %>
-
-  <% Fish.swim %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,18 +1,13 @@
-<!-- stimulusを使用して、connect時にモーダルを開く -->
-<%= turbo_frame_tag "tasks_show_modal" do %>
-  <div data-controller="show-modal">
-    <div data-show-modal-target="modal_top">
-      <dialog data-show-modal-target="task_modal" id="tasks_show_modal" class="modal" <%= @tasks_show_modal_open ? 'open' : ' ' %> >
+<%= turbo_frame_tag "tasks_show_modal_#{@task.id}" do %>
+  <dialog id="tasks_show_modal_<%= @task.id %>_target" class="modal" <%= @tasks_show_modal_open ? 'open' : ' ' %> >
 
-        <!-- まずはturbo_frame_tagを使ってtasks/showでモーダルの部分を表示 -->
-        <!-- tasks#updateでturbo_stremasを使って、モーダルの部分を_tasks_showファイルに置換しています -->
+    <%# まずはturbo_frame_tagを使ってtasks/showでモーダルの部分を表示 %>
+    <%# tasks#updateでturbo_stremasを使って、モーダルの部分を_tasks_showファイルに置換しています %>
 
-        <%= render "tasks/tasks_show_modal_content", task: @task %>
+    <%= render "tasks/tasks_show_modal_content", task: @task %>
 
-        <form method="dialog" class="modal-backdrop">
-          <button>close</button>
-        </form>
-      </dialog>
-    </div>
-  </div>
+    <form method="dialog" class="modal-backdrop">
+      <button>close</button>
+    </form>
+  </dialog>
 <% end %>

--- a/app/views/tasks/update.turbo_stream.erb
+++ b/app/views/tasks/update.turbo_stream.erb
@@ -12,7 +12,7 @@
     <%= render "flash" %>
   <% end %>
 
-  <%= turbo_stream.replace "tasks_show_modal" do %>
+  <%= turbo_stream.replace "tasks_show_modal_#{@task.id}" do %>
     <%= render "tasks_show_modal", task: @task, tasks_show_modal_open: @tasks_show_modal_open %>
   <% end %>
 


### PR DESCRIPTION
<!-- github copilot レビューは日本語でお願いします -->
# 概要

<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->

tasks/showのモーダルの表示が、選択から時間差があり、体験が良くなかったので、事前に読み込むことで素早く表示されるようにしました。

# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイントです -->

- app/views
  - gantt_chart
    - _task_chart.html.erb 22, 20
      - 変更に伴い、リンクでturbo_frameを置換するのではなく、置換済みのモーダルをbuttonで開く形に変更
    - show.html.erb 5, 1
      - 置換用のturbo_frameを、遅延読み込み用の記載に変更
      - @milestonesをeachで回し、milestone.tasksをeachで回して処理

- milestones
  - show.html.erb 4, 1
    - 置換用のturbo_frameを、遅延読み込み用の記載に変更

- tasks
  - _task.html.erb 6, 4
    - buttonでモーダルを開く形に変更
  - _tasks_show_modal.html.erb 4, 4
    - 個別にモーダルを表示する関係で、turbo_frameのidにtaskのidを追加。
    - コメントアウトの記載を<%#%>に変更
  - _tasks_show_modal_content.html.erb 2, 2
    - 文字サイズが変ったので、明示的に指定
  - create.turbo_stream.erb 4, 0
    - create後に置換用のモーダルを配置
  - destroy.turbo_stream.erb 1, 3
    - destroy後に削除したtaskのモーダルを削除する形に変更
  - index.html.erb 6, 1
    - 置換用のturbo_frameを、遅延読み込み用の記載に変更
  - show.html.erb 9, 14
    - turbo_frameのidを個別のものに変更し、stimulus用の要素を削除
  - update.turbo_stream.erb 1, 1
    - idを個別のものに変更

<!-- github copilot レビューは日本語でお願いします -->

