### PR TITLE
ゲストユーザーのSNS(x)共有ボタンを無効化しました

### DIFF
--- a/app/views/application/_x_share_button.html.erb
+++ b/app/views/application/_x_share_button.html.erb
@@ -1,0 +1,30 @@
+<%# instance: Milestone or User %>
+
+<% if instance.class == Milestone && instance.user.guest? %>
+  <div class="tooltip" data-tip="ゲストユーザーは使用できません">
+    <div class="btn btn-disabled rounded-lg px-3">
+      <%= image_tag 'x-logo.png', class: 'h-6 w-6' %>
+    </div>
+  </div>
+<% elsif instance.class == Milestone %>
+  <%= link_to "https://twitter.com/intent/tweet?text=%23星にタスクを%0A&url=https://hoshi-ni-task-wo.onrender.com/milestones/#{instance.id}", target: "_blank", class: "btn btn-neutral rounded-lg px-3" do %>
+    <%= image_tag 'x-logo.png', class: 'h-6 w-6' %>
+  <% end %>
+<% elsif instance.class == User && instance.guest? %>
+  <div class="tooltip" data-tip="ゲストユーザーは使用できません">
+    <div class="btn btn-disabled rounded-lg px-3">
+      <%= image_tag 'x-logo.png', class: 'h-6 w-6' %>
+    </div>
+  </div>
+<% elsif instance.class == User %>
+  <%= link_to "https://twitter.com/intent/tweet?text=%23星にタスクを%0A&url=https://hoshi-ni-task-wo.onrender.com/users/#{instance.id}", target: "_blank", class: "btn btn-neutral rounded-lg px-3" do %>
+    <%= image_tag 'x-logo.png', class: 'h-6 w-6' %>
+  <% end %>
+<% else %>
+  <div class="tooltip" data-tip="なんらかの原因で使用できません">
+    <div class="btn btn-disabled rounded-lg px-3">
+      <%= image_tag 'x-logo.png', class: 'h-6 w-6' %>
+    </div>
+  </div>
+<% end %>
+

--- a/app/views/gantt_chart/show.html.erb
+++ b/app/views/gantt_chart/show.html.erb
@@ -14,8 +14,8 @@
 </div>
 <%= turbo_frame_tag "tasks_edit_modal" %>
 <%= turbo_frame_tag "milestone_show_modal" %>
-<%= @milestones.each do |milestone| %>
-  <%= milestone.tasks.each do |task| %>
+<% @milestones.each do |milestone| %>
+  <% milestone.tasks.each do |task| %>
     <%= turbo_frame_tag "tasks_show_modal_#{task.id}", src: task_path(task) %>
   <% end %>
 <% end %>

--- a/app/views/milestones/_completed_page.html.erb
+++ b/app/views/milestones/_completed_page.html.erb
@@ -38,7 +38,15 @@
               </div>
 
               <%# publicな星座の時だけシェアボタンを表示 %>
-              <% if @milestone.public? %>
+
+              <% if @milestone.user.guest? %>
+                <div class="tooltip" data-tip="ゲストユーザーは使用できません">
+                  <button class="btn btn-disabled rounded-lg">
+                    <%= image_tag 'x-logo.png', class: 'h-6 w-6' %>
+                    完成をシェアする
+                  </button>
+                </div>
+              <% elsif @milestone.public? %>
                 <%= link_to "https://twitter.com/intent/tweet?text=星座が完成しました%0A%0A%23星にタスクを%0A&url=https://hoshi-ni-task-wo.onrender.com/milestones/#{@milestone.id}", target: "_blank", class: "btn btn-neutral rounded-lg px-3" do %>
                   <%= image_tag 'x-logo.png', class: 'h-6 w-6' %>
                   <p class=" text-xs">完成をシェアする</p>

--- a/app/views/milestones/show.html.erb
+++ b/app/views/milestones/show.html.erb
@@ -136,13 +136,19 @@
           </div>
         </div>
 
-        <% if @milestone.public? %>
         <div class="flex h-full items-center justify-center md:w-1/4">
-          <%= link_to "https://twitter.com/intent/tweet?text=%23星にタスクを%0A&url=https://hoshi-ni-task-wo.onrender.com/milestones/#{@milestone.id}", target: "_blank", class: "btn btn-neutral rounded-lg px-3" do %>
-            <%= image_tag 'x-logo.png', class: 'h-6 w-6' %>
+          <% if @milestone.user.guest? %>
+            <div class="tooltip" data-tip="ゲストユーザーは使用できません">
+              <div class="btn btn-disabled rounded-lg px-3">
+                <%= image_tag 'x-logo.png', class: 'h-6 w-6' %>
+              </div>
+            </div>
+          <% elsif @milestone.public? %>
+            <%= link_to "https://twitter.com/intent/tweet?text=%23星にタスクを%0A&url=https://hoshi-ni-task-wo.onrender.com/milestones/#{@milestone.id}", target: "_blank", class: "btn btn-neutral rounded-lg px-3" do %>
+              <%= image_tag 'x-logo.png', class: 'h-6 w-6' %>
+            <% end %>
           <% end %>
         </div>
-        <% end %>
 
       </div>
     </div>

--- a/app/views/milestones/show.html.erb
+++ b/app/views/milestones/show.html.erb
@@ -137,17 +137,7 @@
         </div>
 
         <div class="flex h-full items-center justify-center md:w-1/4">
-          <% if @milestone.user.guest? %>
-            <div class="tooltip" data-tip="ゲストユーザーは使用できません">
-              <div class="btn btn-disabled rounded-lg px-3">
-                <%= image_tag 'x-logo.png', class: 'h-6 w-6' %>
-              </div>
-            </div>
-          <% elsif @milestone.public? %>
-            <%= link_to "https://twitter.com/intent/tweet?text=%23星にタスクを%0A&url=https://hoshi-ni-task-wo.onrender.com/milestones/#{@milestone.id}", target: "_blank", class: "btn btn-neutral rounded-lg px-3" do %>
-              <%= image_tag 'x-logo.png', class: 'h-6 w-6' %>
-            <% end %>
-          <% end %>
+            <%= render "x_share_button", instance: @milestone %>
         </div>
 
       </div>

--- a/app/views/milestones/show.html.erb
+++ b/app/views/milestones/show.html.erb
@@ -136,9 +136,13 @@
           </div>
         </div>
 
-        <div class="flex h-full items-center justify-center md:w-1/4">
+        <%# ゲストユーザーまたは、公開milestoneの場合に、shareボタン表示 %>
+        <%# ゲストの場合は無効化されたshareボタンになる %>
+        <% if @milestone.user.guest? || @milestone.public? %>
+          <div class="flex h-full items-center justify-center md:w-1/4">
             <%= render "x_share_button", instance: @milestone %>
-        </div>
+          </div>
+        <% end %>
 
       </div>
     </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -38,6 +38,7 @@
       <!-- ゲストユーザーの時は、ユーザー編集ボタンを無効化 -->
       <div class="flex justify-center items-center">
         <div class="flex w-xl <%= current_user?(@user) ? 'justify-between' : 'justify-end' %>">
+
           <% if current_user&.guest? && current_user?(@user) %>
             <div class="tooltip" data-tip="ゲストユーザーは使用できません">
               <button class="btn btn-disabled rounded-lg">ユーザー編集</button>
@@ -45,17 +46,9 @@
           <% elsif current_user?(@user) %>
             <button class="btn btn-accent rounded-lg" onclick="edit_modal.showModal()">ユーザー編集</button>
           <% end %>
-          <% if @user.guest? %>
-            <div class="tooltip" data-tip="ゲストユーザーは使用できません">
-              <div class="btn btn-disabled rounded-lg px-3">
-                <%= image_tag 'x-logo.png', class: 'h-6 w-6' %>
-              </div>
-            </div>
-          <% else %>
-            <%= link_to "https://twitter.com/intent/tweet?text=%23星にタスクを%0A&url=https://hoshi-ni-task-wo.onrender.com/users/#{@user.id}", target: "_blank", class: "btn btn-neutral rounded-lg px-3" do %>
-              <%= image_tag 'x-logo.png', class: 'h-6 w-6' %>
-            <% end %>
-          <% end %>
+
+          <%= render "x_share_button", instance: @user %>
+
         </div>
       </div>
     </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -45,9 +45,17 @@
           <% elsif current_user?(@user) %>
             <button class="btn btn-accent rounded-lg" onclick="edit_modal.showModal()">ユーザー編集</button>
           <% end %>
+          <% if @user.guest? %>
+            <div class="tooltip" data-tip="ゲストユーザーは使用できません">
+              <div class="btn btn-disabled rounded-lg px-3">
+                <%= image_tag 'x-logo.png', class: 'h-6 w-6' %>
+              </div>
+            </div>
+          <% else %>
             <%= link_to "https://twitter.com/intent/tweet?text=%23星にタスクを%0A&url=https://hoshi-ni-task-wo.onrender.com/users/#{@user.id}", target: "_blank", class: "btn btn-neutral rounded-lg px-3" do %>
               <%= image_tag 'x-logo.png', class: 'h-6 w-6' %>
             <% end %>
+          <% end %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!-- github copilot レビューは日本語でお願いします -->
# 概要

<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->

ゲストユーザーのtaskやmilestone、userページは表示されないように設定しているので、SNS共有を行える状態だと誤解を招く可能性があったので、無効化しました。

# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイントです -->

- app/views
  - gantt_chart
    - show.html.erb 2, 2
      - 不要な記述を削除（今回の更新とは関係ない部分の小さなバグ）
  - milestones
    - _completed_page.html.erb 9, 1
      - @milestone.user.guest?がtrueの場合、無効化されたボタンを表示
    - show.html.erb 10, 4
      - 同様のロジックで無効化
  - users
    - show.html.erb 8, 0
      - 同様のロジックで無効化

## スクリーンショット

<!-- Command + Shift + Control + 4 でスクリーンショットして Command + V でここに貼り付けるのが楽。以下のテーブルは必要に応じて使ってください -->
![image](https://github.com/user-attachments/assets/4fbf382c-e5b0-4c59-94d9-8a689bf50d56)

<!-- github copilot レビューは日本語でお願いします -->

