### PR TITLE
fix: 英語の表記を日本語に変更

### DIFF
--- a/app/views/application/_menu_bar.html.erb
+++ b/app/views/application/_menu_bar.html.erb
@@ -4,7 +4,7 @@
   <div class="dropdown dropdown-top hover:opacity-100">
     <button tabindex="0" class="flex flex-col w-full h-full items-center justify-center active:opacity-60">
       <span class="material-symbols-outlined">menu</span>
-      <span class="dock-label">Menu</span>
+      <span class="dock-label">メニュー</span>
     </button>
     <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded z-120 p-5 inline-flex p-2 shadow-xl text-2xl">
 
@@ -30,20 +30,20 @@
       <% else %>
 
         <li>
-          <div class="flex items-center">
+          <%= link_to new_user_session_path, class: "whitespace-nowrap text-base-200 flex items-center inline-flex w-full" do %>
             <span class="material-symbols-outlined">
               login
             </span>
-            <%= link_to "ログイン", new_user_session_path, class: "whitespace-nowrap text-base-200" %>
-          </div>
+            <p class="whitespace-nowrap">ログイン</p>
+          <% end %>
         </li>
         <li>
-          <div class="flex items-center">
+          <%= link_to new_user_registration_path, class: "flex items-center" do %>
             <span class="material-symbols-outlined">
               person_add
             </span>
-            <%= link_to "新規登録", new_user_registration_path, class: "whitespace-nowrap text-base-200" %>
-          </div>
+            <p class="whitespace-nowrap">新規登録</p>
+          <% end %>
         </li>
 
       <% end %>
@@ -96,7 +96,7 @@
       <span class="material-symbols-outlined">
         stacked_bar_chart
       </span>
-      <span class="dock-label">Chart</span>
+      <span class="dock-label">チャート</span>
     <% end %>
   </button>
 
@@ -105,7 +105,7 @@
       <div class="pt-1">
         <%= render 'tasks_icon' %>
       </div>
-      <span class="dock-label">Tasks</span>
+      <span class="dock-label">タスク一覧</span>
     <% end %>
   </button>
 
@@ -134,7 +134,7 @@
       <span class="material-symbols-outlined">
         person
       </span>
-        <span class="dock-label">Sign in</span>
+        <span class="dock-label">ログイン</span>
       <% end %>
   </button>
 

--- a/app/views/application/_menu_bar.html.erb
+++ b/app/views/application/_menu_bar.html.erb
@@ -15,7 +15,7 @@
             <span class="material-symbols-outlined">
               logout
             </span>
-            <p class="whitespace-nowrap"> Log out </p>
+            <p class="whitespace-nowrap">ログアウト</p>
           <% end %>
         </li>
         <li>
@@ -34,7 +34,7 @@
             <span class="material-symbols-outlined">
               login
             </span>
-            <%= link_to "Log in", new_user_session_path, class: "whitespace-nowrap text-base-200" %>
+            <%= link_to "ログイン", new_user_session_path, class: "whitespace-nowrap text-base-200" %>
           </div>
         </li>
         <li>
@@ -42,7 +42,7 @@
             <span class="material-symbols-outlined">
               person_add
             </span>
-            <%= link_to "Sign up", new_user_registration_path, class: "whitespace-nowrap text-base-200" %>
+            <%= link_to "新規登録", new_user_registration_path, class: "whitespace-nowrap text-base-200" %>
           </div>
         </li>
 

--- a/app/views/devise/registrations/_edit_form_modal.html.erb
+++ b/app/views/devise/registrations/_edit_form_modal.html.erb
@@ -24,25 +24,27 @@
               <%= f.text_field :name,
                 autofocus: true,
                 autocomplete: "name",
-                placeholder: "User name",
+                placeholder: "ユーザーネーム*",
+                required: true,
                 class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
-                <span class="floating-label-text">Name</span>
+                <span class="floating-label-text">ユーザーネーム*</span>
             </label>
 
             <label class="floating-label mt-5">
               <%= f.text_field :email,
                 autocomplete: "email",
-                placeholder: "Email address",
+                placeholder: "メールアドレス*",
+                required: true,
                 class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
-                <span class="floating-label-text">Email</span>
+                <span class="floating-label-text">メールアドレス*</span>
             </label>
 
             <label class="floating-label mt-5">
               <%= f.text_area :bio,
                 autocomplete: "bio",
-                placeholder: "Bio (optional)",
+                placeholder: "自己紹介",
                 class: "textarea textarea-lg input-primary w-full text-base-100 bg-base-200 rounded-lg" %>
-                <span class="floating-label-text">Bio</span>
+                <span class="floating-label-text">自己紹介</span>
             </label>
 
             <div class="mt-8">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -30,38 +30,38 @@
           <%= f.text_field :name,
             autofocus: true,
             autocomplete: "name",
-            placeholder: "User name",
+            placeholder: "ユーザーネーム",
             class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
-          <span class="floating-label-text">Name</span>
+          <span class="floating-label-text">ユーザーネーム</span>
         </label>
 
         <label class="floating-label mt-5">
           <%= f.text_field :email,
             autocomplete: "email",
-            placeholder: "Email address",
+            placeholder: "メールアドレス",
             class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
-          <span class="floating-label-text">Email</span>
+          <span class="floating-label-text">メールアドレス</span>
         </label>
 
-        <label class="floating-label mt-5">
+        <label class="floating-label mt-9">
           <%= f.password_field :password,
             autocomplete: "new-password",
-            placeholder: "Password",
+            placeholder: "パスワード",
             class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
-          <span class="floating-label-text">Password</span>
+          <span class="floating-label-text">パスワード</span>
         </label>
 
         <label class="floating-label mt-5">
           <%= f.password_field :password_confirmation,
             autocomplete: "new-password",
-            placeholder: "Confirm Password",
+            placeholder: "パスワード(確認)",
             class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
-          <span class="floating-label-text">Confirm Password</span>
+          <span class="floating-label-text">パスワード(確認)</span>
         </label>
 
         <% if @minimum_password_length %>
           <p class="mt-2 text-xs">
-          <em><%= @minimum_password_length %> characters minimum</em>
+          <em><%= @minimum_password_length %> 文字以上にしてください</em>
           </p>
         <% end %>
 
@@ -70,11 +70,11 @@
         </div>
       <% end %>
 
-      <div class="mt-6 text-center">
+      <div class="mt-8 text-center">
         <%= link_to "アカウントをお持ちの方はこちら", new_session_path(resource_name), class: "text-sm text-base-200 hover:underline" %>
       </div>
 
-      <div class="divider my-5">
+      <div class="divider my-8">
         または
       </div>
       <div class="flex justify-center items-center">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -28,27 +28,27 @@
           <%= f.text_field :email,
                 autofocus: true,
                 autocomplete: "email",
-                placeholder: "Email address",
+                placeholder: "メールアドレス",
             class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
-          <span class="floating-label-text">Email</span>
+          <span class="floating-label-text">メールアドレス</span>
         </label>
 
         <label class="floating-label mt-5">
           <%= f.password_field :password,
             autocomplete: "current-password",
-            placeholder: "Password",
+            placeholder: "パスワード",
             class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
-          <span class="floating-label-text">Email</span>
+          <span class="floating-label-text">パスワード</span>
         </label>
 
-        <%= f.submit "ログイン", class: "btn btn-secondary text-base-200 w-full mt-5" %>
+        <%= f.submit "ログイン", class: "btn btn-secondary text-base-200 w-full mt-8" %>
       <% end %>
 
-      <div class="mt-4 text-center space-y-2">
+      <div class="my-8 text-center space-y-2">
         <%= link_to "アカウント作成はこちら", new_registration_path(resource_name), class: "text-sm hover:underline" %>
       </div>
 
-      <div class="divider">または</div>
+      <div class="divider mb-8">または</div>
 
       <div class="flex justify-center items-center">
         <%= button_to user_line_omniauth_authorize_path, data: { turbo: false } do %>

--- a/app/views/gantt_chart/milestone_show.html.erb
+++ b/app/views/gantt_chart/milestone_show.html.erb
@@ -57,9 +57,9 @@
                   <!-- 説明 -->
                   <div class="flex w-full items-center justify-center">
                     <div class="card w-full text-neutral">
-                      <p class="card-title h-5 pl-2 text-sm text-primary">Description</p>
+                      <p class="card-title h-5 pl-2 text-sm text-primary">詳細</p>
                       <div class="flex min-h-24 w-full items-center justify-center rounded-xl bg-primary p-3">
-                        <%= @milestone.description.present? ? safe_join(@milestone.description.split("\n"),tag(:br)) : "説明はありません" %>
+                        <%= @milestone.description.present? ? safe_join(@milestone.description.split("\n"),tag(:br)) : "詳細はありません" %>
                       </div>
                     </div>
                   </div>

--- a/app/views/milestones/_milestones_edit_modal.html.erb
+++ b/app/views/milestones/_milestones_edit_modal.html.erb
@@ -19,9 +19,11 @@
               <%= f.text_field :title,
                 autofocus: true,
                 autocomplete: "title",
-                placeholder: "Title",
+                placeholder: "タイトル* (~25文字)",
+                required: true,
+                maxlength: 25,
                 class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
-                <span class="floating-label-text">Title</span>
+                <span class="floating-label-text">タイトル* (~25文字)</span>
             </label>
 
             <div class="mt-5 w-full">
@@ -36,10 +38,10 @@
 
             <div class="flex justify-center">
             <label class="mt-5 w-50">
-              <span class="text-base-200 text-sm">Start Date (6ヶ月後まで)</span>
+              <span class="text-base-200 text-sm">開始日 (6ヶ月後まで)</span>
               <%= f.date_field :start_date,
                 autocomplete: "Start Date",
-                placeholder: "Start Date",
+                placeholder: "開始日",
                 max: Date.today + 6.months,
                 min: Date.today - 6.months,
                 class: "text-base-200 bg-base-100 rounded-full p-3 w-full" %>
@@ -49,10 +51,10 @@
 
             <div class="flex justify-center">
             <label class="mt-5 w-50">
-              <span class="text-base-200 text-sm">End Date (6ヶ月後まで)</span>
+              <span class="text-base-200 text-sm">終了日 (6ヶ月後まで)</span>
               <%= f.date_field :end_date,
                 autocomplete: "End Date",
-                placeholder: "End Date",
+                placeholder: "終了日",
                 max: Date.today + 6.months,
                 class: "text-base-200 bg-base-100 rounded-full p-3 w-full" %>
             </label>
@@ -61,9 +63,10 @@
             <label class="floating-label mt-10">
               <%= f.text_area :description,
                 autocomplete: "description",
-                placeholder: "Description",
+                placeholder: "説明 (~100文字)",
+                maxlength: 100,
                 class: "textarea textarea-lg input-primary w-full text-base-100 bg-base-200 rounded-lg" %>
-                <span class="floating-label-text">Description</span>
+                <span class="floating-label-text">説明 (~100文字)</span>
             </label>
 
             <div class="divider mb-4 mt-10">ON/OFF</div>

--- a/app/views/milestones/_milestones_new_modal.html.erb
+++ b/app/views/milestones/_milestones_new_modal.html.erb
@@ -20,9 +20,11 @@
               <%= f.text_field :title,
                 autofocus: true,
                 autocomplete: "title",
-                placeholder: "Title",
+                placeholder: "タイトル* (~25文字)",
+                required: true,
+                maxlength: 25,
                 class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
-                <span class="floating-label-text">Title</span>
+                <span class="floating-label-text">タイトル* (~25文字)</span>
             </label>
 
             <div class="mt-5 w-full">
@@ -38,10 +40,10 @@
 
             <div class="flex justify-center">
               <label class="mt-5 w-50">
-                <span class="text-base-200 text-sm">Start Date (6ヶ月後まで)</span>
+                <span class="text-base-200 text-sm">開始日 (6ヶ月後まで)</span>
                 <%= f.date_field :start_date,
                   autocomplete: "Start Date",
-                  placeholder: "Start Date",
+                  placeholder: "開始日",
                   max: Date.today + 6.months,
                   min: Date.today - 6.months,
                   class: "text-base-200 bg-base-100 rounded-full p-3 w-full" %>
@@ -51,10 +53,10 @@
 
             <div class="flex justify-center">
               <label class="mt-5 w-50">
-                <span class="text-base-200 text-sm">End Date (6ヶ月後まで)</span>
+                <span class="text-base-200 text-sm">終了日 (6ヶ月後まで)</span>
                 <%= f.date_field :end_date,
                   autocomplete: "End Date",
-                  placeholder: "End Date",
+                  placeholder: "終了日",
                   max: Date.today + 6.months,
                   class: "text-base-200 bg-base-100 rounded-full p-3 w-full" %>
               </label>
@@ -63,9 +65,10 @@
             <label class="floating-label mt-10">
               <%= f.text_area :description,
                 autocomplete: "description",
-                placeholder: "Description",
+                placeholder: "詳細 (~100文字)",
+                maxlength: 100,
                 class: "textarea textarea-lg input-primary w-full text-base-100 bg-base-200 rounded-lg" %>
-                <span class="floating-label-text">Description</span>
+                <span class="floating-label-text">詳細 (~100文字)</span>
             </label>
 
             <div class="divider mb-4 mt-10">ON/OFF</div>
@@ -79,7 +82,9 @@
 
               <div class="mt-5">
                 <%= f.label :is_on_chart, "チャートに表示する", class: "cursor-pointer mr-2" %>
-                <%= f.check_box :is_on_chart, class: "toggle toggle-xl bg-base-100 checked:bg-primary checked:text-accent checked:border-primary" %>
+                <%= f.check_box :is_on_chart,
+                  checked: false,
+                  class: "toggle toggle-xl bg-base-100 checked:bg-primary checked:text-accent checked:border-primary" %>
               </div>
             </div>
             </div>

--- a/app/views/tasks/_tasks_edit_modal_content.html.erb
+++ b/app/views/tasks/_tasks_edit_modal_content.html.erb
@@ -17,26 +17,28 @@
 
           <label class="floating-label">
             <%= f.collection_select :milestone_id, @milestones, :id, :title,
-              { include_blank: "Select Milestone" },
+              { include_blank: "星座を選択" },
               class: "select select-lg select-primary w-full text-base-100 bg-base-200" %>
-            <span class="floating-label-text">Milestone</span>
+            <span class="floating-label-text">星座</span>
           </label>
 
           <label class="floating-label mt-10">
             <%= f.text_field :title,
               autofocus: true,
               autocomplete: "title",
-              placeholder: "Title",
+              placeholder: "タイトル* (~25文字)",
+              required: true,
+              maxlength: 25,
               class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
-            <span class="floating-label-text">Title</span>
+              <span class="floating-label-text">タイトル* (~25文字)</span>
           </label>
 
           <div class="flex justify-center">
             <label class="mt-5 w-50">
-              <span class="text-base-200 text-sm">Start Date</span>
+              <span class="text-base-200 text-sm">開始日</span>
               <%= f.date_field :start_date,
                 autocomplete: "Start Date",
-                placeholder: "Start Date",
+                placeholder: "開始日",
                 min: @task.milestone&.start_date,
                 max: @task.milestone&.end_date,
                 class: "text-base-200 bg-base-100 rounded-full p-3 w-full" %>
@@ -46,10 +48,10 @@
 
           <div class="flex justify-center">
             <label class="mt-5 w-50">
-              <span class="text-base-200 text-sm">End Date</span>
+              <span class="text-base-200 text-sm">終了日</span>
               <%= f.date_field :end_date,
                 autocomplete: "End Date",
-                placeholder: "End Date",
+                placeholder: "終了日",
                 min: @task.milestone&.start_date,
                 max: @task.milestone&.end_date,
                 class: "text-base-200 bg-base-100 rounded-full p-3 w-full" %>
@@ -59,9 +61,10 @@
           <label class="floating-label mt-5">
             <%= f.text_area :description,
               autocomplete: "description",
-              placeholder: "Description",
+              placeholder: "説明 (~100文字)",
+              maxlength: 100,
               class: "textarea textarea-lg input-primary w-full text-base-100 bg-base-200 rounded-lg" %>
-            <span class="floating-label-text">Description</span>
+            <span class="floating-label-text">説明 (~100文字)</span>
           </label>
 
           <div class="mt-10">

--- a/app/views/tasks/_tasks_new_modal_content.html.erb
+++ b/app/views/tasks/_tasks_new_modal_content.html.erb
@@ -20,14 +20,15 @@
               <%= f.collection_select :milestone_id, @milestones, :id, :title,
                         {:selected => "#{@milestones.first.id}"},
                         class: "select select-lg select-primary w-full text-base-100 bg-base-200" %>
-                        <span class="floating-label-text">Milestone</span>
+                        <span class="floating-label-text">星座</span>
             </label>
           <% else %>
             <label class="floating-label">
               <%= f.collection_select :milestone_id, @milestones, :id, :title,
-                        { include_blank: "Select Milestone" },
+                        { include_blank: "星座を選択してください" },
                         class: "select select-lg select-primary w-full text-base-100 bg-base-200" %>
-                        <span class="floating-label-text">Milestone</span>
+                        <span class="floating-label-text">星座
+                        </span>
             </label>
           <% end %>
 
@@ -35,18 +36,20 @@
             <%= f.text_field :title,
                       autofocus: true,
                       autocomplete: "title",
-                      placeholder: "Title",
+                      placeholder: "タイトル* (~25文字)",
+                      required: true,
+                      maxlength: 25,
                       class: "input input-lg input-primary w-full text-base-100 bg-base-200" %>
-                      <span class="floating-label-text">Title</span>
+                      <span class="floating-label-text">タイトル* (~25文字)</span>
           </label>
 
           <% if @from_milestone_show == true %>
             <div class="flex justify-center">
               <label class="mt-5 w-50">
-                <span class="text-base-200 text-sm">Start Date</span>
+                <span class="text-base-200 text-sm">開始日</span>
                 <%= f.date_field :start_date,
                   autocomplete: "Start Date",
-                  placeholder: "Start Date",
+                  placeholder: "開始日",
                   min: @milestones.first&.start_date,
                   max: @milestones.first&.end_date,
                   class: "text-base-200 bg-base-100 rounded-full p-3 w-full" %>
@@ -56,10 +59,10 @@
 
             <div class="flex justify-center">
               <label class="mt-5 w-50">
-                <span class="text-base-200 text-sm">End Date</span>
+                <span class="text-base-200 text-sm">終了日</span>
                 <%= f.date_field :end_date,
                   autocomplete: "End Date",
-                  placeholder: "End Date",
+                  placeholder: "終了日",
                   min: @milestones.first&.start_date,
                   max: @milestones.first&.end_date,
                   class: "text-base-200 bg-base-100 rounded-full p-3 w-full" %>
@@ -69,7 +72,7 @@
 
             <div class="flex justify-center">
               <label class="mt-5 w-50">
-                <span class="text-base-200 text-sm">Start Date</span>
+                <span class="text-base-200 text-sm">開始日</span>
                 <%= f.date_field :start_date,
                   autocomplete: "Start Date",
                   placeholder: "Start Date",
@@ -81,7 +84,7 @@
 
             <div class="flex justify-center">
               <label class="mt-5 w-50">
-                <span class="text-base-200 text-sm">End Date</span>
+                <span class="text-base-200 text-sm">終了日</span>
                 <%= f.date_field :end_date,
                   autocomplete: "End Date",
                   placeholder: "End Date",
@@ -96,16 +99,16 @@
           <label class="floating-label mt-5">
             <%= f.text_area :description,
                       autocomplete: "description",
-                      placeholder: "Description",
+                      placeholder: "詳細 (~100文字)",
                       class: "textarea textarea-lg input-primary w-full text-base-100 bg-base-200 rounded-lg" %>
-                      <span class="floating-label-text">Description</span>
+                      <span class="floating-label-text">詳細 (~100文字)</span>
           </label>
 
           <label class="floating-label mt-5">
             <%= f.collection_select :progress, Task.progresses.keys, :to_s, :humanize,
                       { include_blank: "Select Progress" },
                       class: "select select-lg select-primary w-full text-base-100 bg-base-200" %>
-                      <span class="floating-label-text">Progress</span>
+                      <span class="floating-label-text">進捗*</span>
           </label>
 
 

--- a/app/views/tasks/_tasks_new_modal_content.html.erb
+++ b/app/views/tasks/_tasks_new_modal_content.html.erb
@@ -100,6 +100,7 @@
             <%= f.text_area :description,
                       autocomplete: "description",
                       placeholder: "詳細 (~100文字)",
+                      maxlength: 100,
                       class: "textarea textarea-lg input-primary w-full text-base-100 bg-base-200 rounded-lg" %>
                       <span class="floating-label-text">詳細 (~100文字)</span>
           </label>

--- a/app/views/tasks/_tasks_show_modal_content.html.erb
+++ b/app/views/tasks/_tasks_show_modal_content.html.erb
@@ -33,7 +33,7 @@
           <!-- タイトル -->
           <div class="flex w-full items-center justify-center">
             <div class="card w-full text-neutral">
-              <p class="card-title h-5 pl-2 text-sm text-primary">Title</p>
+              <p class="card-title h-5 pl-2 text-sm text-primary">タイトル</p>
               <div class="flex w-full items-center justify-center rounded-xl text-xl bg-primary p-3">
                 <%= @task.title %>
               </div>
@@ -42,25 +42,32 @@
 
 
           <!-- 期間 -->
+          <% start_date_and_end_date_present = @task.start_date.present? && @task.end_date.present? %>
+
           <% if @task.start_date.present? || @task.end_date.present? %>
-            <div class="flex w-full justify-between px-5 text-neutral">
-              <div class="card flex h-full w-2/5 flex-col justify-center bg-primary p-2">
-                <div>
-                  <%= @task.start_date&.year %>年
+            <div class="flex w-full px-5 text-neutral <%= start_date_and_end_date_present ? "justify-between" : "justify-center" %>">
+
+              <% if @task.start_date.present? %>
+                <div class="card flex h-full w-2/5 flex-col justify-center bg-primary p-2">
+                  <div>
+                    <%= @task.start_date&.year %>
+                  </div>
+                  <div class="w-full font-bold md:text-2xl">
+                    <%= to_short_date(@task.start_date) %>
+                  </div>
                 </div>
-                <div class="w-full font-bold md:text-2xl">
-                  <%= to_short_date(@task.start_date) %>
-                </div>
-              </div>
+              <% end %>
               <div class="flex w-1/5 items-center justify-center">
-                <p class="w-full text-5xl text-primary">~</p>
-              </div>
+              <p class="w-full text-5xl text-primary">~</p>
+            </div>
+            <% if @task.end_date.present? %>
               <div class="card flex h-full w-2/5 flex-col justify-center bg-primary p-2">
-                <%= @task.end_date&.year %>年<br>
+                <%= @task.end_date&.year %><br>
                 <div class="w-full font-bold md:text-2xl">
                   <%= to_short_date(@task.end_date) %>
                 </div>
               </div>
+            <% end %>
             </div>
           <% else %>
             <div class="flex w-full justify-center">
@@ -73,9 +80,9 @@
           <!-- 説明 -->
           <div class="flex w-full items-center justify-center">
             <div class="card w-full text-neutral">
-              <p class="card-title h-5 pl-2 text-sm text-primary">Description</p>
+              <p class="card-title h-5 pl-2 text-sm text-primary">詳細</p>
               <div class="flex min-h-24 w-full items-center justify-center rounded-xl bg-primary p-3">
-                <%= @task.description.present? ? safe_join(@task.description.split("\n"),tag(:br)) : "説明はありません" %>
+                <%= @task.description.present? ? safe_join(@task.description.split("\n"),tag(:br)) : "詳細はありません" %>
               </div>
             </div>
           </div>


### PR DESCRIPTION
<!-- github copilot レビューは日本語でお願いします -->
# 概要

<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->

formとmodalのタイトルや詳細が英語表記になっていたので、日本語に修正しました。

# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイントです -->

app/views/application/_menu_bar.html.erb 3, 3
app/views/devise/registrations/_edit_form_modal.html.erb 8, 6
app/views/devise/registrations/new.html.erb 12, 12
app/views/devise/sessions/new.html.erb 7, 7
app/views/gantt_chart/milestone_show.html.erb 2, 2
app/views/milestones/_milestones_edit_modal.html.erb 11, 8
app/views/milestones/_milestones_new_modal.html.erb 14, 9
app/views/tasks/_tasks_edit_modal_content.html.erb 13, 10
app/views/tasks/_tasks_new_modal_content.html.erb 17, 14
app/views/tasks/_tasks_show_modal_content.html.erb 21, 14

上記のファイルに関して、英語を日本語に修正しました。
また、一部デザインを微調整しました。
<!-- github copilot レビューは日本語でお願いします -->

