### PR TITLE
限定公開機能用テーブルを作成しました closes #170

### DIFF
--- a/db/migrate/20250508232217_create_limited_sharing_milestones.rb
+++ b/db/migrate/20250508232217_create_limited_sharing_milestones.rb
@@ -1,0 +1,18 @@
+class CreateLimitedSharingMilestones < ActiveRecord::Migration[7.2]
+  def change
+    create_table :limited_sharing_milestones, id: :string, limit: 12 do |t|
+      t.string :title, null: false
+      t.text :description
+      t.integer :progress, default: 0, null: false
+      t.string :color, default: "#FFDF5E", null: false
+      t.date :start_date
+      t.date :end_date
+      t.text :completed_comment
+
+      t.references :user, null: false, foreign_key: true
+      t.references :constellation, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250508232217_create_limited_sharing_milestones.rb
+++ b/db/migrate/20250508232217_create_limited_sharing_milestones.rb
@@ -1,6 +1,6 @@
 class CreateLimitedSharingMilestones < ActiveRecord::Migration[7.2]
   def change
-    create_table :limited_sharing_milestones, id: :string, limit: 12 do |t|
+    create_table :limited_sharing_milestones, id: :string, limit: 21 do |t|
       t.string :title, null: false
       t.text :description
       t.integer :progress, default: 0, null: false

--- a/db/migrate/20250509014703_create_limited_sharing_tasks.rb
+++ b/db/migrate/20250509014703_create_limited_sharing_tasks.rb
@@ -1,0 +1,13 @@
+class CreateLimitedSharingTasks < ActiveRecord::Migration[7.2]
+  def change
+    create_table :limited_sharing_tasks, id: :string, limit: 12 do |t|
+      t.string :title, null: false
+      t.text :description
+      t.integer :progress, default: 0, null: false
+      t.daate :start_date
+      t.date :end_date
+      t.references :limited_sharing_milestone, foreign_key: true, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250509014703_create_limited_sharing_tasks.rb
+++ b/db/migrate/20250509014703_create_limited_sharing_tasks.rb
@@ -1,12 +1,12 @@
 class CreateLimitedSharingTasks < ActiveRecord::Migration[7.2]
   def change
-    create_table :limited_sharing_tasks, id: :string, limit: 12 do |t|
+    create_table :limited_sharing_tasks, id: :string, limit: 21 do |t|
       t.string :title, null: false
       t.text :description
       t.integer :progress, default: 0, null: false
-      t.daate :start_date
+      t.date :start_date
       t.date :end_date
-      t.references :limited_sharing_milestone, foreign_key: true, null: false
+      t.references :limited_sharing_milestone, type: :string, foreign_key: true, null: false
       t.timestamps
     end
   end

--- a/db/migrate/20250509033937_add_is_on_chart_to_limited_sharing_milestones.rb
+++ b/db/migrate/20250509033937_add_is_on_chart_to_limited_sharing_milestones.rb
@@ -1,0 +1,5 @@
+class AddIsOnChartToLimitedSharingMilestones < ActiveRecord::Migration[7.2]
+  def change
+    add_column :limited_sharing_milestones, :is_on_chart, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_21_060919) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_08_232217) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,22 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_21_060919) do
     t.integer "number_of_stars", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "limited_sharing_milestones", id: { type: :string, limit: 12 }, force: :cascade do |t|
+    t.string "title", null: false
+    t.text "description"
+    t.integer "progress", default: 0, null: false
+    t.string "color", default: "#FFDF5E", null: false
+    t.date "start_date"
+    t.date "end_date"
+    t.text "completed_comment"
+    t.bigint "user_id", null: false
+    t.bigint "constellation_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["constellation_id"], name: "index_limited_sharing_milestones_on_constellation_id"
+    t.index ["user_id"], name: "index_limited_sharing_milestones_on_user_id"
   end
 
   create_table "milestones", force: :cascade do |t|
@@ -74,6 +90,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_21_060919) do
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 
+  add_foreign_key "limited_sharing_milestones", "constellations"
+  add_foreign_key "limited_sharing_milestones", "users"
   add_foreign_key "milestones", "constellations"
   add_foreign_key "milestones", "users"
   add_foreign_key "tasks", "milestones"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_08_232217) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_09_014703) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,7 +21,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_08_232217) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "limited_sharing_milestones", id: { type: :string, limit: 12 }, force: :cascade do |t|
+  create_table "limited_sharing_milestones", id: { type: :string, limit: 21 }, force: :cascade do |t|
     t.string "title", null: false
     t.text "description"
     t.integer "progress", default: 0, null: false
@@ -35,6 +35,18 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_08_232217) do
     t.datetime "updated_at", null: false
     t.index ["constellation_id"], name: "index_limited_sharing_milestones_on_constellation_id"
     t.index ["user_id"], name: "index_limited_sharing_milestones_on_user_id"
+  end
+
+  create_table "limited_sharing_tasks", id: { type: :string, limit: 21 }, force: :cascade do |t|
+    t.string "title", null: false
+    t.text "description"
+    t.integer "progress", default: 0, null: false
+    t.date "start_date"
+    t.date "end_date"
+    t.string "limited_sharing_milestone_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["limited_sharing_milestone_id"], name: "index_limited_sharing_tasks_on_limited_sharing_milestone_id"
   end
 
   create_table "milestones", force: :cascade do |t|
@@ -92,6 +104,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_08_232217) do
 
   add_foreign_key "limited_sharing_milestones", "constellations"
   add_foreign_key "limited_sharing_milestones", "users"
+  add_foreign_key "limited_sharing_tasks", "limited_sharing_milestones"
   add_foreign_key "milestones", "constellations"
   add_foreign_key "milestones", "users"
   add_foreign_key "tasks", "milestones"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_09_014703) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_09_033937) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -33,6 +33,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_09_014703) do
     t.bigint "constellation_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "is_on_chart", default: false, null: false
     t.index ["constellation_id"], name: "index_limited_sharing_milestones_on_constellation_id"
     t.index ["user_id"], name: "index_limited_sharing_milestones_on_user_id"
   end


### PR DESCRIPTION
<!-- github copilot レビューは日本語でお願いします -->
# 概要
<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->

限定公開機能の際に、既存のmilestones, tasksをコピーするためのテーブルを作成しました。
idをnanoidで実装予定のため、string型の21文字以内制限を設けています。
また、URLを知っていれば全員が見られるため、is_publicカラムは設定していません。

# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイントです -->

- migrate
  - 20250508232217_create_limited_sharing_milestones.rb 18, 0
  - 20250509014703_create_limited_sharing_tasks.rb 13, 0
  - 20250509033937_add_is_on_chart_to_limited_sharing_milestones.rb 5, 0

- schema.rb 33, 1

<!-- github copilot レビューは日本語でお願いします -->

