### PR TITLE
限定公開機能を実装しました。 closes #50

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ gem 'line-bot-api'
 gem "mini_magick"
 gem "meta-tags", require: 'meta_tags'
 
+gem "nanoid"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,7 @@ GEM
     msgpack (1.8.0)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
+    nanoid (2.0.0)
     net-http (0.6.0)
       uri
     net-imap (0.5.6)
@@ -411,6 +412,7 @@ DEPENDENCIES
   line-bot-api
   meta-tags
   mini_magick
+  nanoid
   omniauth-line
   omniauth-rails_csrf_protection
   pg (~> 1.1)

--- a/app/controllers/limited_sharing_milestones_controller.rb
+++ b/app/controllers/limited_sharing_milestones_controller.rb
@@ -20,35 +20,18 @@ class LimitedSharingMilestonesController < ApplicationController
     return redirect_to root_path unless current_user?(base_milestone.user)
 
     # base_milestoneのデータで、share_milestoneを作成
-    @milestone = LimitedSharingMilestone.new(
-      user: base_milestone.user,
-      title: base_milestone.title,
-      description: base_milestone.description,
-      progress: base_milestone.progress,
-      color: base_milestone.color,
-      start_date: base_milestone.start_date,
-      end_date: base_milestone.end_date,
-      completed_comment: base_milestone.completed_comment,
-      is_on_chart: base_milestone.is_on_chart,
-      constellation: base_milestone.constellation
-    )
+    @milestone = generate_limited_sharing_milestone(base_milestone)
 
     # base_milestoneのtasksをsharing_milestoneにコピー
-    base_milestone.tasks.each do |task|
-      sharing_task = LimitedSharingTask.new(
-        title: task.title,
-        description: task.description,
-        progress: task.progress,
-        start_date: task.start_date,
-        end_date: task.end_date,
-        user: task.user
-      )
-      sharing_task.milestone = @milestone
-      @milestone.tasks << sharing_task
+    base_milestone.tasks.each do |base_task|
+      task = generate_limited_sharing_task(base_task)
+      task.milestone = @milestone
+      @milestone.tasks << task
     end
 
     if @milestone.save
-      flash.now[:notice] = "共有用の星座が作成されました"
+      flash[:notice] = "共有用の星座が作成されました"
+      redirect_to share_milestone_path(@milestone) and return
     else
       flash[:alert] = "共有用の星座の作成に失敗しました"
       redirect_to milestone_path(base_milestone) and return
@@ -77,6 +60,32 @@ class LimitedSharingMilestonesController < ApplicationController
 
     flash[:alert] = "この星座にはアクセスできません"
     redirect_to root_path
+  end
+
+  def generate_limited_sharing_milestone(base_milestone)
+    LimitedSharingMilestone.new(
+      user: base_milestone.user,
+      title: base_milestone.title,
+      description: base_milestone.description,
+      progress: base_milestone.progress,
+      color: base_milestone.color,
+      start_date: base_milestone.start_date,
+      end_date: base_milestone.end_date,
+      completed_comment: base_milestone.completed_comment,
+      is_on_chart: base_milestone.is_on_chart,
+      constellation: base_milestone.constellation
+    )
+  end
+
+  def generate_limited_sharing_task(base_task)
+    LimitedSharingTask.new(
+      title: base_task.title,
+      description: base_task.description,
+      progress: base_task.progress,
+      start_date: base_task.start_date,
+      end_date: base_task.end_date,
+      user: base_task.user
+    )
   end
 
   def prepare_for_chart(milestone)

--- a/app/controllers/limited_sharing_milestones_controller.rb
+++ b/app/controllers/limited_sharing_milestones_controller.rb
@@ -1,0 +1,90 @@
+class LimitedSharingMilestonesController < ApplicationController
+  include GanttChartHelper
+  before_action :authenticate_user!, only: [:create]
+  before_action :set_milestone, only: [:show, :destroy]
+  before_action :validate_another_user, only: [:destroy]
+
+  def show
+    @title = "限定公開の星座"
+    @is_milestone_completed = (@milestone.progress == "completed")
+    @is_not_milestone_on_chart = @milestone.is_on_chart == false
+
+    prepare_for_chart(@milestone) if @milestone.is_on_chart
+    @milestone_tasks = @milestone.tasks
+  end
+
+  def create
+    milestone = Milestone.find(params[:id])
+    return redirect_to root_path unless current_user?(milestone.user)
+
+    @sharing_milestone = LimitedSharingMilestone.new(
+      user: milestone.user,
+      title: milestone.title,
+      description: milestone.description,
+      progress: milestone.progress,
+      color: milestone.color,
+      start_date: milestone.start_date,
+      end_date: milestone.end_date,
+      completed_comment: milestone.completed_comment,
+      is_on_chart: milestone.is_on_chart,
+      constellation: milestone.constellation
+    )
+
+    milestone.tasks.each do |task|
+      sharing_task = LimitedSharingTask.new(
+        title: task.title,
+        description: task.description,
+        progress: task.progress,
+        start_date: task.start_date,
+        end_date: task.end_date,
+        user: task.user
+      )
+      sharing_task.milestone = @sharing_milestone
+      @sharing_milestone.tasks << sharing_task
+      logger.swim("#{task.id} => #{sharing_task.inspect}")
+    end
+
+    if @sharing_milestone.save
+      flash.now[:notice] = "共有用の星座が作成されました"
+    else
+      @sharing_milestone.tasks.each do |task|
+        task.errors.full_messages.each do |message|
+          logger.swim(message)
+        end
+      end
+      flash[:alert] = "共有用の星座の作成に失敗しました"
+      redirect_to milestone_path(milestone) and return
+    end
+  end
+
+  def destroy
+    @milestone.destroy
+    flash[:notice] = "共有用の星座が削除されました"
+    redirect_to milestones_path, status: :see_other
+  end
+
+  private
+
+  def set_milestone
+    @milestone = LimitedSharingMilestone.find_by(id: params[:id])
+
+    return if @milestone
+
+    flash[:alert] = "指定された星座が見つかりません"
+    redirect_to root_path
+  end
+
+  def validate_another_user
+    return if current_user?(@milestone.user)
+
+    flash[:alert] = "この星座にはアクセスできません"
+    redirect_to root_path
+  end
+
+  def prepare_for_chart(milestone)
+    # milestone_chartの幅と位置情報を計算
+    @milestone_widths, @milestone_lefts = milestone_widths_lefts_hash([milestone])
+    @date_range = date_range([milestone])
+    @chart_total_width = @milestone_widths[milestone.id].to_i + 40
+  end
+end

--- a/app/controllers/limited_sharing_milestones_controller.rb
+++ b/app/controllers/limited_sharing_milestones_controller.rb
@@ -9,6 +9,7 @@ class LimitedSharingMilestonesController < ApplicationController
     @is_milestone_completed = (@milestone.progress == "completed")
     @is_not_milestone_on_chart = @milestone.is_on_chart == false
 
+    prepare_meta_tags(@milestone)
     prepare_for_chart(@milestone) if @milestone.is_on_chart
     @milestone_tasks = @milestone.tasks
   end
@@ -93,5 +94,13 @@ class LimitedSharingMilestonesController < ApplicationController
     @milestone_widths, @milestone_lefts = milestone_widths_lefts_hash([milestone])
     @date_range = date_range([milestone])
     @chart_total_width = @milestone_widths[milestone.id].to_i + 40
+  end
+
+  def prepare_meta_tags(milestone)
+    set_meta_tags og: {
+      title: milestone.title,
+      description: "#{milestone.title}の限定公開ページです。",
+      url: share_milestone_url(milestone)
+    }
   end
 end

--- a/app/controllers/limited_sharing_tasks_controller.rb
+++ b/app/controllers/limited_sharing_tasks_controller.rb
@@ -1,0 +1,11 @@
+class LimitedSharingTasksController < ApplicationController
+  before_action :set_task, only: [:show]
+
+  def show; end
+
+  private
+
+  def set_task
+    @task = LimitedSharingTask.find(params[:id])
+  end
+end

--- a/app/controllers/milestones_controller.rb
+++ b/app/controllers/milestones_controller.rb
@@ -11,6 +11,7 @@ class MilestonesController < ApplicationController
     @user = current_user
     user_milestones = @user.milestones
     @milestone = Milestone.new
+    @sharing_milestones = @user.limited_sharing_milestones
     @completed_milestones = user_milestones.where(progress: "completed")&.order(created_at: :desc)
     @not_completed_milestones = user_milestones.where&.not(progress: "completed")&.order(created_at: :desc)
     @title = "星座一覧"

--- a/app/helpers/gantt_chart_helper.rb
+++ b/app/helpers/gantt_chart_helper.rb
@@ -4,7 +4,15 @@ module GanttChartHelper
     milestone_widths = {}
     milestone_lefts = {}
 
-    task_counts = Task.where(milestone_id: milestones.map(&:id)).group(:milestone_id).count
+    # マイルストーンのタスク数を取得
+    if milestones.first.instance_of?(Milestone)
+      task_counts = Task.where(milestone_id: milestones.map(&:id)).group(:milestone_id).count
+    elsif milestones.first.instance_of?(LimitedSharingMilestone)
+      # 渡されたmilestonesがLimitedSharingMilestoneの場合
+      # rubocop:disable Layout/LineLength
+      task_counts = LimitedSharingTask.where(limited_sharing_milestone_id: milestones.map(&:id)).group(:limited_sharing_milestone_id).count
+      # rubocop:enable Layout/LineLength
+    end
 
     milestones.each do |milestone|
       task_counts[milestone.id] = 0 if task_counts[milestone.id].nil?

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,11 +2,20 @@
 import "@hotwired/turbo-rails"
 import "./controllers"
 import { bgStarShow } from "./bgStarShow"
+import { groupBtnHoverRemoveGroupLinkCardBg } from "./groupBtnHoverRemoveGroupLinkCardBg"
 
 document.addEventListener("turbo:load", function() {
+  // 背景の星を表示
   bgStarShow();
+
+  // 完了ボタンのホバー時にグループリンクカードの背景を変更
+  groupBtnHoverRemoveGroupLinkCardBg();
 });
 
 document.addEventListener("DOMContentLoaded", function() {
+  // 背景の星を表示
   bgStarShow();
+
+  // 完了ボタンのホバー時にグループリンクカードの背景を変更
+  groupBtnHoverRemoveGroupLinkCardBg();
 });

--- a/app/javascript/bgStarShow.js
+++ b/app/javascript/bgStarShow.js
@@ -4,7 +4,7 @@ function generateBoxShadows(count) {
   const shadows = [];
   for (let i = 0; i < count; i++) {
     const x = Math.floor(Math.random() * 2000);
-    const y = Math.floor(Math.random() * 4000);
+    const y = Math.floor(Math.random() * 6000);
     // 白い星を生成
     shadows.push(`${x}px ${y}px rgba(255, 255, 255, 50%)`);
   }
@@ -12,9 +12,9 @@ function generateBoxShadows(count) {
 }
 
 // 各星要素に対するランダムな box-shadow を生成
-const star1Shadows = generateBoxShadows(1000);
-const star2Shadows = generateBoxShadows(200);
-const star3Shadows = generateBoxShadows(100);
+const star1Shadows = generateBoxShadows(1500);
+const star2Shadows = generateBoxShadows(300);
+const star3Shadows = generateBoxShadows(150);
 
 // 要素取得
 const stars1 = document.getElementById('stars1');

--- a/app/javascript/groupBtnHoverRemoveGroupLinkCardBg.js
+++ b/app/javascript/groupBtnHoverRemoveGroupLinkCardBg.js
@@ -1,0 +1,20 @@
+export function groupBtnHoverRemoveGroupLinkCardBg() {
+  const removeHoverBtns = document.querySelectorAll(".remove_hover_btn");
+  const linkCards = document.querySelectorAll(".link_card");
+
+  if (removeHoverBtns.length > 0) {
+    removeHoverBtns.forEach(function(removeHoverBtn) {
+      removeHoverBtn.addEventListener("mouseover", function() {
+        linkCards.forEach(function(linkCard) {
+          linkCard.classList.remove("group-hover:bg-base-300/30");
+        });
+      });
+
+      removeHoverBtn.addEventListener("mouseout", function() {
+        linkCards.forEach(function(linkCard) {
+          linkCard.classList.add("group-hover:bg-base-300/30");
+        });
+      });
+    });
+  }
+}

--- a/app/models/concerns/nanoid_generator.rb
+++ b/app/models/concerns/nanoid_generator.rb
@@ -3,7 +3,6 @@
 module NanoidGenerator
   extend ActiveSupport::Concern
 
-
   ID_ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
   ID_LENGTH = 21
   MAX_RETRY = 1000

--- a/app/models/concerns/nanoid_generator.rb
+++ b/app/models/concerns/nanoid_generator.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module NanoIdGenerator
+  extend ActiveSupport::Concern
+
+  included do
+    before_create :set_id
+  end
+
+  ID_ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  ID_LENGTH = 21
+  MAX_RETRY = 1000
+
+  class_methods do
+    def generate_nanoid(alphabet: ID_ALPHABET, size: ID_LENGTH)
+      Nanoid.generate(size:, alphabet:)
+    end
+  end
+
+  def set_id
+    return if id.present?
+
+    MAX_RETRY.times do
+      self.id = generate_id
+      return unless self.class.exists?(id:)
+    end
+    raise "Failed to generate a unique public id after #{MAX_RETRY} attempts"
+  end
+
+  def generate_id
+    self.class.generate_nanoid
+  end
+end

--- a/app/models/concerns/nanoid_generator.rb
+++ b/app/models/concerns/nanoid_generator.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
-module NanoIdGenerator
+module NanoidGenerator
   extend ActiveSupport::Concern
 
-  included do
-    before_create :set_id
-  end
 
   ID_ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
   ID_LENGTH = 21

--- a/app/models/limited_sharing_milestone.rb
+++ b/app/models/limited_sharing_milestone.rb
@@ -9,7 +9,6 @@ class LimitedSharingMilestone < ApplicationRecord
   validates :progress, presence: true
   validates :color, presence: true
   validates :user_id, presence: true
-  validates :is_on_chart, presence: true
 
   enum progress: [:not_started, :in_progress, :completed]
 

--- a/app/models/limited_sharing_milestone.rb
+++ b/app/models/limited_sharing_milestone.rb
@@ -1,9 +1,9 @@
 class LimitedSharingMilestone < ApplicationRecord
-  include NanoIdGenerator
+  include NanoidGenerator
 
   belongs_to :user
   belongs_to :constellation, optional: true
-  has_many :limited_sharing_tasks, dependent: :destroy
+  has_many :tasks, dependent: :destroy, class_name: "LimitedSharingTask"
 
   validates :title, presence: true
   validates :progress, presence: true
@@ -11,5 +11,24 @@ class LimitedSharingMilestone < ApplicationRecord
   validates :user_id, presence: true
   validates :is_on_chart, presence: true
 
-  enum progress: { not_started: 0, in_progress: 1, completed: 2 }
+  enum progress: [:not_started, :in_progress, :completed]
+
+  # ######################################
+  # メソッド
+  # ######################################
+  def initialize(attributes = nil)
+    super
+    set_id
+  end
+
+  def completed_tasks_percentage
+    tasks = self.tasks
+    return 0 if tasks.empty?
+
+    completed_tasks = tasks.select { |task| task.progress == "completed" }.length
+    total_tasks = tasks.length
+
+    n = completed_tasks.to_f / total_tasks
+    (n * 100).round
+  end
 end

--- a/app/models/limited_sharing_milestone.rb
+++ b/app/models/limited_sharing_milestone.rb
@@ -1,0 +1,15 @@
+class LimitedSharingMilestone < ActiveRecord::Base
+  include NanoIdGenerator
+
+  belongs_to :user
+  belongs_to :constellation, optional: true
+  has_many :limited_sharing_tasks, dependent: :destroy
+
+  validates :title, presence: true
+  validates :progress, presence: true
+  validates :color, presence: true
+  validates :user_id, presence: true
+  validates :is_on_chart, presence: true
+
+  enum progress: { not_started: 0, in_progress: 1, completed: 2 }
+end

--- a/app/models/limited_sharing_milestone.rb
+++ b/app/models/limited_sharing_milestone.rb
@@ -1,4 +1,4 @@
-class LimitedSharingMilestone < ActiveRecord::Base
+class LimitedSharingMilestone < ApplicationRecord
   include NanoIdGenerator
 
   belongs_to :user

--- a/app/models/limited_sharing_task.rb
+++ b/app/models/limited_sharing_task.rb
@@ -1,11 +1,40 @@
 class LimitedSharingTask < ApplicationRecord
-  include NanoIdGenerator
+  include NanoidGenerator
 
-  belongs_to :limited_sharing_milestone
+  belongs_to :milestone, class_name: "LimitedSharingMilestone", foreign_key: "limited_sharing_milestone_id"
+  belongs_to :user
 
   validates :title, presence: true
   validates :progress, presence: true
   validates :limited_sharing_milestone_id, presence: true
 
-  enum progress: { not_started: 0, in_progress: 1, completed: 2 }
+  enum progress: [:not_started, :in_progress, :completed]
+
+  # dateが両方nilのものを弾くscope
+  scope :valid_dates, -> { where.not(start_date: nil, end_date: nil) }
+  scope :start_date_asc, -> { order(start_date: :asc) }
+
+  # ######################################
+  # メソッド
+  # ######################################
+  def initialize(attributes = nil)
+    super
+    set_id
+  end
+
+  def milestone_completed?
+    milestone&.progress == "completed"
+  end
+
+  def completed?
+    progress == "completed"
+  end
+
+  def in_progress?
+    progress == "in_progress"
+  end
+
+  def not_started?
+    progress == "not_started"
+  end
 end

--- a/app/models/limited_sharing_task.rb
+++ b/app/models/limited_sharing_task.rb
@@ -1,0 +1,11 @@
+class LimitedSharingTask < ActiveRecord::Base
+  include NanoIdGenerator
+
+  belongs_to :limited_sharing_milestone
+
+  validates :title, presence: true
+  validates :progress, presence: true
+  validates :limited_sharing_milestone_id, presence: true
+
+  enum progress: { not_started: 0, in_progress: 1, completed: 2 }
+end

--- a/app/models/limited_sharing_task.rb
+++ b/app/models/limited_sharing_task.rb
@@ -1,4 +1,4 @@
-class LimitedSharingTask < ActiveRecord::Base
+class LimitedSharingTask < ApplicationRecord
   include NanoIdGenerator
 
   belongs_to :limited_sharing_milestone

--- a/app/models/milestone.rb
+++ b/app/models/milestone.rb
@@ -39,6 +39,11 @@ class Milestone < ApplicationRecord
   # ######################################
   # メソッド
   # ######################################
+
+  def tasks_completed?
+    tasks.all? { |task| task.progress == "completed" }
+  end
+
   def completed_tasks_percentage
     tasks = self.tasks
     return 0 if tasks.empty?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,8 @@ class User < ApplicationRecord
 
   has_many :tasks, dependent: :destroy
   has_many :milestones, dependent: :destroy
+  has_many :limited_sharing_milestones, dependent: :destroy
+  has_many :limited_sharing_tasks, dependent: :destroy
 
   # Lineログイン用の設定
   def social_profile(provider)

--- a/app/views/application/_title_header.html.erb
+++ b/app/views/application/_title_header.html.erb
@@ -1,6 +1,6 @@
 <%= link_to root_path do %>
   <%= image_tag 'mikaduki.png', class: 'absolute top-5 left-5 z-0 h-[50px] w-[50px]' %>
 <% end %>
-<div class="p-10 text-4xl flex items-center justify-center">
+<div class="p-10 text-2xl flex items-center justify-center md:text-4xl">
   <%= title %>
 </div>

--- a/app/views/gantt_chart/_chart_layout.html.erb
+++ b/app/views/gantt_chart/_chart_layout.html.erb
@@ -34,7 +34,11 @@
               background-color: <%= milestone_color %>b3;
               border-color: <%= milestone_color %>cc;
               ">
-              <%= link_to gantt_chart_milestone_show_path(milestone), class: "hover:cursor-pointer", data: { turbo_frame: "milestone_show_modal" } do %>
+              <% if milestone.class == Milestone %>
+                <%= link_to gantt_chart_milestone_show_path(milestone), class: "hover:cursor-pointer", data: { turbo_frame: "milestone_show_modal" } do %>
+                  <%= milestone.title %>
+                <% end %>
+              <% else %>
                 <%= milestone.title %>
               <% end %>
             </div>

--- a/app/views/gantt_chart/_chart_layout.html.erb
+++ b/app/views/gantt_chart/_chart_layout.html.erb
@@ -34,7 +34,7 @@
               background-color: <%= milestone_color %>b3;
               border-color: <%= milestone_color %>cc;
               ">
-              <% if milestone.class == Milestone %>
+              <% if milestone.is_a?(Milestone) %>
                 <%= link_to gantt_chart_milestone_show_path(milestone), class: "hover:cursor-pointer", data: { turbo_frame: "milestone_show_modal" } do %>
                   <%= milestone.title %>
                 <% end %>

--- a/app/views/limited_sharing_milestones/_milestone.html.erb
+++ b/app/views/limited_sharing_milestones/_milestone.html.erb
@@ -1,0 +1,48 @@
+<div id="milestone_<%=milestone.id%>" class="mb-4 card w-full p-4 bg-base-300/40 shadow-xl/10">
+
+  <div class="flex w-full items-center text-left">
+    <%= link_to share_milestone_path(milestone), class: "w-full p-1 rounded-xl hover:bg-base-300/30 active:bg-base-300/30" do %>
+
+      <!-- タイトル, 日付, マーク -->
+      <div class="flex w-full mb-2">
+        <% if milestone.completed? %>
+          <%= render "milestones/complete_stars_icon", color: milestone.color, width: 40, height: 40 %>
+        <% else %>
+          <div class="hidden sm:flex sm:items-center">
+            <%= render "stars_icon", color: milestone.color, width: 40, height: 40 %>
+          </div>
+          <div class="flex items-center sm:hidden">
+            <%= render "stars_icon", color: milestone.color %>
+          </div>
+        <% end %>
+
+        <div class="ml-2 w-7/10">
+          <p class="text-lg"><%= milestone.title %></p>
+          <p class="text-sm"><%= to_short_date(milestone&.start_date) %> ~ <%= to_short_date(milestone&.end_date) %></p>
+        </div>
+      </div>
+
+
+      <!-- 詳細 -->
+      <div class="text-left mb-4">
+        <% if milestone.description.present? %>
+          <p class="text-sm hidden sm:block"><%= milestone.description.truncate(30) %></p>
+          <p class="text-sm sm:hidden"><%= milestone.description.truncate(15) %></p>
+        <% else %>
+          <p class="text-lg">詳細はありません</p>
+        <% end %>
+      </div>
+
+    <% end %>
+  </div>
+
+  <% if !milestone.completed? %>
+    <!-- 進捗 -->
+    <div class="flex w-full mb-2">
+    <%= render "milestones/milestone_completed_percent_bar", milestone: milestone, milestone_tasks: milestone.tasks.all %>
+    </div>
+  <% end %>
+      <div class="flex justify-end w-full">
+        <p class="">作成日 : <%= to_short_date(milestone.created_at) %></p>
+      </div>
+</div>

--- a/app/views/limited_sharing_milestones/_milestone.html.erb
+++ b/app/views/limited_sharing_milestones/_milestone.html.erb
@@ -1,9 +1,10 @@
-<div id="milestone_<%=milestone.id%>" class="mb-4 card w-full p-4 bg-base-300/40 shadow-xl/10">
+<div class="mb-4 card w-full p-4 bg-base-300/40 shadow-xl/10">
 
-    <%= link_to share_milestone_path(milestone), class: "w-full mb-2 rounded-xl hover:bg-base-300/30 active:bg-base-300/30" do %>
+  <div class="group">
+    <%= link_to share_milestone_path(milestone) do %>
 
       <!-- タイトル, 日付, マーク -->
-      <div class="flex w-full">
+      <div class="flex w-full items-center group-hover:bg-base-300/30 group-active:bg-base-300/30 rounded-t-xl">
         <% if milestone.completed? %>
           <%= render "milestones/complete_stars_icon", color: milestone.color, width: 40, height: 40 %>
         <% else %>
@@ -22,22 +23,23 @@
     <% end %>
 
 
-  <div class="flex w-full items-center text-left">
-    <%= link_to share_milestone_path(milestone), class: "w-full px-1 rounded-xl hover:bg-base-300/30 active:bg-base-300/30" do %>
-      <p class="text-sm"><%= to_short_date(milestone&.start_date) %> ~ <%= to_short_date(milestone&.end_date) %></p>
+    <div class="flex w-full items-center text-left">
+      <%= link_to share_milestone_path(milestone), class: "pt-2 w-full px-1 rounded-b-xl group-hover:bg-base-300/30 active:bg-base-300/30" do %>
+        <p class="text-sm"><%= to_short_date(milestone&.start_date) %> ~ <%= to_short_date(milestone&.end_date) %></p>
 
 
-      <!-- 詳細 -->
-      <div class="text-left mb-4">
-        <% if milestone.description.present? %>
-          <p class="text-sm hidden sm:block"><%= milestone.description.truncate(30) %></p>
-          <p class="text-sm sm:hidden"><%= milestone.description.truncate(15) %></p>
-        <% else %>
-          <p class="text-lg">詳細はありません</p>
-        <% end %>
-      </div>
+        <!-- 詳細 -->
+        <div class="text-left mb-4">
+          <% if milestone.description.present? %>
+            <p class="text-sm hidden sm:block"><%= milestone.description.truncate(30) %></p>
+            <p class="text-sm sm:hidden"><%= milestone.description.truncate(15) %></p>
+          <% else %>
+            <p class="text-lg">詳細はありません</p>
+          <% end %>
+        </div>
 
-    <% end %>
+      <% end %>
+    </div>
   </div>
 
   <% if !milestone.completed? %>

--- a/app/views/limited_sharing_milestones/_milestone.html.erb
+++ b/app/views/limited_sharing_milestones/_milestone.html.erb
@@ -1,10 +1,9 @@
 <div id="milestone_<%=milestone.id%>" class="mb-4 card w-full p-4 bg-base-300/40 shadow-xl/10">
 
-  <div class="flex w-full items-center text-left">
-    <%= link_to share_milestone_path(milestone), class: "w-full p-1 rounded-xl hover:bg-base-300/30 active:bg-base-300/30" do %>
+    <%= link_to share_milestone_path(milestone), class: "w-full mb-2 rounded-xl hover:bg-base-300/30 active:bg-base-300/30" do %>
 
       <!-- タイトル, 日付, マーク -->
-      <div class="flex w-full mb-2">
+      <div class="flex w-full">
         <% if milestone.completed? %>
           <%= render "milestones/complete_stars_icon", color: milestone.color, width: 40, height: 40 %>
         <% else %>
@@ -16,11 +15,16 @@
           </div>
         <% end %>
 
-        <div class="ml-2 w-7/10">
+        <div class="ml-2">
           <p class="text-lg"><%= milestone.title %></p>
-          <p class="text-sm"><%= to_short_date(milestone&.start_date) %> ~ <%= to_short_date(milestone&.end_date) %></p>
         </div>
       </div>
+    <% end %>
+
+
+  <div class="flex w-full items-center text-left">
+    <%= link_to share_milestone_path(milestone), class: "w-full px-1 rounded-xl hover:bg-base-300/30 active:bg-base-300/30" do %>
+      <p class="text-sm"><%= to_short_date(milestone&.start_date) %> ~ <%= to_short_date(milestone&.end_date) %></p>
 
 
       <!-- 詳細 -->

--- a/app/views/limited_sharing_milestones/_share_confirm_modal.html.erb
+++ b/app/views/limited_sharing_milestones/_share_confirm_modal.html.erb
@@ -1,0 +1,33 @@
+<dialog id="share_confirm_modal" class="modal">
+  <div class="modal-box max-h-[90vh]">
+    <p class="text-center pb-4">ESC or 画面外を押すと閉じます</p>
+    <div class="flex w-full items-center justify-center">
+      <div class="card z-10 flex h-2xl w-full justify-center bg-base-300 p-5 px-0 md:px-5 text-center md:w-2xl">
+        <div class="flex items-center justify-center text-secondary mb-3">
+          <p class="text-xl">星座の公開を行う</p>
+        </div>
+        <div class="flex h-full items-center justify-center mb-8">
+          <p class="text-sm text-base-200">※注意<br>URLを知っている人であれば<br>誰でも閲覧できるようになります。</p>
+        </div>
+
+        <%= button_to "公開", limited_sharing_milestones_path(id: @milestone.id),
+          method: :post,
+          class: "btn btn-primary px-9" %>
+
+      </div>
+    </div>
+  <div class="modal-action flex justify-center">
+    <form method="dialog">
+      <button class="btn btn-accent px-9">
+        キャンセル
+      </button>
+    </form>
+  </div>
+  </div>
+
+
+
+  <form method="dialog" class="modal-backdrop">
+    <button>close</button>
+  </form>
+</dialog>

--- a/app/views/limited_sharing_milestones/create.turbo_stream.erb
+++ b/app/views/limited_sharing_milestones/create.turbo_stream.erb
@@ -1,4 +1,0 @@
-
-  <%= turbo_stream.replace "flash" do %>
-    <%= render "flash" %>
-  <% end %>

--- a/app/views/limited_sharing_milestones/create.turbo_stream.erb
+++ b/app/views/limited_sharing_milestones/create.turbo_stream.erb
@@ -1,0 +1,4 @@
+
+  <%= turbo_stream.replace "flash" do %>
+    <%= render "flash" %>
+  <% end %>

--- a/app/views/limited_sharing_milestones/show.html.erb
+++ b/app/views/limited_sharing_milestones/show.html.erb
@@ -47,7 +47,7 @@
       <!-- 進捗バー -->
       <div class="flex items-center justify-center text-2xl">
         <div class="my-10 h-12 w-xl rounded-full bg-primary px-5 text-xl text-neutral">
-          <%= render "milestone_completed_percent_bar", milestone: @milestone, milestone_tasks: @milestone_tasks %>
+          <%= render "milestones/milestone_completed_percent_bar", milestone: @milestone, milestone_tasks: @milestone_tasks %>
         </div>
       </div>
 
@@ -98,20 +98,8 @@
 
     <!-- 公開・表示設定 -->
     <div class="mb-8 flex h-full md:h-[100px] items-center justify-center">
-      <div class="flex flex-col h-full w-xl md:flex-row <%= @milestone.public? ? "" : "justify-center" %>">
         <div class="flex mb-8 items-center justify-center rounded-xl text-base-200 md:w-3/4 md:mb-0">
           <div>
-            <div class="mb-3 flex items-center md:justify-end">
-              <div class="mr-2 text-center">
-                全体に公開する：
-              </div>
-              <% if @milestone.is_public %>
-                <span class="badge badge-md badge-primary md:badge-lg">ON</span>
-              <% else %>
-                <span class="badge badge-md badge-base-300 md:badge-lg">OFF</span>
-              <% end %>
-            </div>
-
             <%if @is_milestone_completed %>
               <div class="flex items-center">
                 <div class="mr-2 text-center">
@@ -135,102 +123,15 @@
             <% end %>
           </div>
         </div>
-
-        <%# ゲストユーザーまたは、公開milestoneの場合に、shareボタン表示 %>
-        <%# ゲストの場合は無効化されたshareボタンになる %>
-        <% if @milestone.user.guest? || @milestone.public? %>
-          <div class="flex h-full items-center justify-center md:w-1/4">
-            <%= render "x_share_button", instance: @milestone %>
-          </div>
-        <% end %>
-
       </div>
-    </div>
 
     <!-- button -->
     <% if current_user?(@milestone.user) %>
       <div class="flex h-12 w-full justify-center text-neutral">
-        <% if current_user.guest? %>
-          <div class="tooltip" data-tip="ゲストユーザーは使用できません">
-            <div class="btn btn-disabled mr-5 h-12 w-25 md:w-42">
-              削除
-            </div>
-          </div>
-        <% else %>
-          <div class="btn btn-error mr-5 h-12 w-25 md:w-42" onclick="delete_confirm_modal.showModal()">
-            削除
-          </div>
+        <%= button_to limited_sharing_milestone_path(@milestone), method: :delete, data: { turbo_confirm: "本当に削除しますか？" }, class: "btn btn-error mr-5 h-12 w-25 md:w-42" do %>
+          削除
         <% end %>
-        <button class="btn btn-accent h-12 w-25 md:w-42" onclick="milestones_edit_modal.showModal()">
-          編集
-        </button>
       </div>
-
-      <% if @milestone.user.guest? %>
-        <div class="relative left-4 btn bg-transparent text-base-200 hover:cursor-default">
-          <div class="tooltip" data-tip="ゲストユーザーは使用できません">
-            <span class="material-symbols-outlined">
-              content_copy
-            </span>
-          </div>
-        </div>
-      <% else %>
-        <%= link_to milestones_copy_path(@milestone), data: { turbo_frame: "milestones_copy_modal"}, class: "relative left-4 btn bg-base-300 hover:bg-base-200/10 text-base-200" do %>
-          <div class="tooltip" data-tip="タスクをコピーする">
-            <span id="copy_icon_<%=@milestone.id%>" class="material-symbols-outlined">
-              content_copy
-            </span>
-          </div>
-        <% end %>
-      <% end %>
-      <div class="dropdown dropdown-top dropdown-center relative left-4">
-        <div tabindex="0" role="button" class="btn btn-circle btn-ghost btn-xs text-info">
-          <span class="material-symbols-outlined text-base-200">
-            help
-          </span>
-        </div>
-        <div
-          tabindex="0"
-          class="card dropdown-content bg-base-100 rounded-box z-1 w-70 mr-10 shadow-xl border-1">
-          <div tabindex="0" class="card-body text-sm px-1">
-            <div class="text-center">
-              <p class="mb-2">始点を設定しない場合は、<br>
-              そのままコピーします。</p>
-
-              <div class="divider"></div>
-
-              <p class="mb-2">始点を指定した場合、</p>
-              <p class="mb-2">・開始日または終了日を始点の日に<br>
-              設定してコピーします。</p>
-
-              <div class="divider"></div>
-              <p class="mb-4">開始日も終了日も無い星座の場合は<br>
-              日付を設定せずにコピーします。
-              </p>
-
-              <div class="divider"></div>
-              <p class="mb-2">紐づくタスクは<br>
-              <p class="mb-2">・星座に日付がある場合は<br>
-              それを基準としてコピーします。</p>
-              <p class="mb-2">・星座に日付が無い場合は、<br>
-              タスクの内の一番早い日付を基準に
-              <br>コピーします。</p>
-
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <%= button_to limited_sharing_milestones_path(id: @milestone.id),
-        method: :post,
-        class: "relative left-4 btn bg-base-300 hover:bg-base-200/10 text-base-200" do %>
-        <div class="tooltip" data-tip="他のユーザーと共有する">
-          <span class="material-symbols-outlined">
-            share
-          </span>
-        </div>
-      <% end %>
-
     <% end %>
 
     <!-- タスクの表示部分 -->
@@ -240,11 +141,6 @@
         <!-- タスク -->
         <input type="radio" name="my_tabs" class="tab" aria-label="タスク" checked="checked"/>
         <div class="tab-content bg-base-100 p-3">
-
-          <% if !@is_milestone_completed && current_user?(@milestone.user) %>
-            <!-- 新規作成ボタン -->
-            <%= render "tasks/add_task_button", milestone: @milestone %>
-          <% end %>
 
           <!-- タスク一覧 -->
           <%= render "tasks/tasks", tasks: @milestone_tasks %>
@@ -285,17 +181,15 @@
 </div>
 
 <% if current_user?(@milestone.user) %>
-  <%= render 'milestones/milestones_edit_modal', milestone: @milestone %>
   <%= render 'milestones/delete_confirm_modal' %>
   <%= turbo_frame_tag "tasks_edit_modal" %>
   <%= turbo_frame_tag "tasks_new_modal" %>
   <%= turbo_frame_tag "tasks_copy_modal" %>
-  <%= turbo_frame_tag "milestones_copy_modal" %>
 <% end %>
 
 <%= turbo_frame_tag "milestone_show_modal" %>
 <% @milestone_tasks.each do |task| %>
-  <%= turbo_frame_tag "tasks_show_modal_#{task.id}", src: task_path(task)%>
+  <%= turbo_frame_tag "tasks_show_modal_#{task.id}" %>
 <% end %>
 
 

--- a/app/views/limited_sharing_milestones/show.html.erb
+++ b/app/views/limited_sharing_milestones/show.html.erb
@@ -16,9 +16,9 @@
         <%= "#{@milestone.title} 座" %>
       </div>
       <div class="mx-auto flex justify-center items-center rounded-full h-52 w-52 bg-base-200">
-      <%= link_to  milestone_constellation_url(@milestone) do %>
-        <%= image_tag "#{@milestone.constellation.image_name}.webp", class: "h-50 w-50 mask mask-circle", oncontextmenu: "return false;", onselectstart: "return false;", onmousedown: "return false;" %>
-      <% end %>
+        <%= link_to  milestone_constellation_url(@milestone) do %>
+          <%= image_tag "#{@milestone.constellation.image_name}.webp", class: "h-50 w-50 mask mask-circle", oncontextmenu: "return false;", onselectstart: "return false;", onmousedown: "return false;" %>
+        <% end %>
       </div>
       <%= link_to  milestone_constellation_url(@milestone) do %>
         <p class="text-xs text-base-200 link">画像：<%= @milestone.constellation.name %></p>
@@ -57,7 +57,7 @@
         <div class="flex h-35 w-full justify-center text-neutral">
           <div class="flex w-xl justify-between p-3">
             <div class="card flex h-full w-2/5 flex-col justify-center bg-primary p-2">
-                <%= @milestone.start_date&.year %>
+              <%= @milestone.start_date&.year %>
               <div class="w-full text-xl">
                 <%= to_short_date(@milestone.start_date) %>
               </div>
@@ -98,38 +98,38 @@
 
     <!-- 公開・表示設定 -->
     <div class="mb-8 flex h-full md:h-[100px] items-center justify-center">
-        <div class="flex items-center justify-center rounded-xl text-base-200 md:w-3/4 md:mb-0">
-          <div>
-            <%if @is_milestone_completed %>
-              <div class="flex items-center">
-                <div class="mr-2 text-center">
-                  チャートに表示する：
-                </div>
-                <p class="text-primary">
-                星座完成済み
-                </p>
+      <div class="flex items-center justify-center rounded-xl text-base-200 md:w-3/4 md:mb-0">
+        <div>
+          <%if @is_milestone_completed %>
+            <div class="flex items-center">
+              <div class="mr-2 text-center">
+                チャートに表示する：
               </div>
-            <% else %>
-              <div class="flex items-center">
-                <div class="mr-2 text-center">
-                  チャートに表示する：
-                </div>
-                <% if @milestone.is_on_chart %>
-                  <span class="badge badge-md badge-primary md:badge-lg">ON</span>
-                <% else %>
-                  <span class="badge badge-md badge-base-300 md:badge-lg">OFF</span>
-                <% end %>
+              <p class="text-primary">
+              星座完成済み
+              </p>
+            </div>
+          <% else %>
+            <div class="flex items-center">
+              <div class="mr-2 text-center">
+                チャートに表示する：
               </div>
-            <% end %>
-          </div>
+              <% if @milestone.is_on_chart %>
+                <span class="badge badge-md badge-primary md:badge-lg">ON</span>
+              <% else %>
+                <span class="badge badge-md badge-base-300 md:badge-lg">OFF</span>
+              <% end %>
+            </div>
+          <% end %>
         </div>
       </div>
+    </div>
 
     <!-- button -->
     <% if current_user?(@milestone.user) %>
       <div class="flex h-12 w-full justify-center text-neutral mb-8">
-        <%= button_to limited_sharing_milestone_path(@milestone), method: :delete, data: { turbo_confirm: "本当に削除しますか？" }, class: "btn btn-error mr-5 h-12 w-25 md:w-42" do %>
-          削除
+        <%= button_to limited_sharing_milestone_path(@milestone), method: :delete, data: { turbo_confirm: "本当に取り消しますか？" }, class: "btn btn-error mr-5 h-12 w-30" do %>
+          共有取り消し
         <% end %>
       </div>
     <% end %>

--- a/app/views/limited_sharing_milestones/show.html.erb
+++ b/app/views/limited_sharing_milestones/show.html.erb
@@ -98,7 +98,7 @@
 
     <!-- 公開・表示設定 -->
     <div class="mb-8 flex h-full md:h-[100px] items-center justify-center">
-        <div class="flex mb-8 items-center justify-center rounded-xl text-base-200 md:w-3/4 md:mb-0">
+        <div class="flex items-center justify-center rounded-xl text-base-200 md:w-3/4 md:mb-0">
           <div>
             <%if @is_milestone_completed %>
               <div class="flex items-center">
@@ -127,7 +127,7 @@
 
     <!-- button -->
     <% if current_user?(@milestone.user) %>
-      <div class="flex h-12 w-full justify-center text-neutral">
+      <div class="flex h-12 w-full justify-center text-neutral mb-8">
         <%= button_to limited_sharing_milestone_path(@milestone), method: :delete, data: { turbo_confirm: "本当に削除しますか？" }, class: "btn btn-error mr-5 h-12 w-25 md:w-42" do %>
           削除
         <% end %>

--- a/app/views/limited_sharing_milestones/show.html.erb
+++ b/app/views/limited_sharing_milestones/show.html.erb
@@ -189,7 +189,7 @@
 
 <%= turbo_frame_tag "milestone_show_modal" %>
 <% @milestone_tasks.each do |task| %>
-  <%= turbo_frame_tag "tasks_show_modal_#{task.id}" %>
+  <%= turbo_frame_tag "tasks_show_modal_#{task.id}", src: share_task_path(task) %>
 <% end %>
 
 

--- a/app/views/limited_sharing_tasks/show.html.erb
+++ b/app/views/limited_sharing_tasks/show.html.erb
@@ -1,0 +1,13 @@
+<%= turbo_frame_tag "tasks_show_modal_#{@task.id}" do %>
+  <dialog id="tasks_show_modal_<%= @task.id %>_target" class="modal" <%= @tasks_show_modal_open ? 'open' : ' ' %> >
+
+    <%# まずはturbo_frame_tagを使ってtasks/showでモーダルの部分を表示 %>
+    <%# tasks#updateでturbo_stremasを使って、モーダルの部分を_tasks_showファイルに置換しています %>
+
+    <%= render "tasks/tasks_show_modal_content", task: @task %>
+
+    <form method="dialog" class="modal-backdrop">
+      <button>close</button>
+    </form>
+  </dialog>
+<% end %>

--- a/app/views/milestones/_milestone.html.erb
+++ b/app/views/milestones/_milestone.html.erb
@@ -1,27 +1,30 @@
 <div id="milestone_<%=milestone.id%>" class="card mb-4 w-full p-4 bg-base-300/40 shadow-xl/10">
 
-  <%= link_to milestone_path(milestone), class: "w-full mb-2 rounded-xl hover:bg-base-300/30 active:bg-base-300/30" do %>
-    <!-- タイトル, 日付, マーク -->
-    <div class="flex w-full">
-      <% if completed %>
-        <%= render "milestones/complete_stars_icon", color: milestone.color, width: 40, height: 40 %>
-      <% else %>
-        <div class="hidden sm:flex sm:items-center">
-          <%= render "stars_icon", color: milestone.color, width: 40, height: 40 %>
-        </div>
-        <div class="flex items-center sm:hidden">
-          <%= render "stars_icon", color: milestone.color %>
-        </div>
-      <% end %>
+  <%# groupにhoverするとbgが変わる %>
+  <%# remove_hover_btn要素にhoverするとjsによってlink_card要素のgroup-hover:bg-base-300/30が取り除かれる %>
+  <div class="group">
+    <%= link_to milestone_path(milestone), class: "link_card flex w-full items-center group-hover:bg-base-300/30 group-active:bg-base-300/30 rounded-t-xl" do %>
+      <!-- タイトル, 日付, マーク -->
+      <div class="flex w-full items-center">
+        <% if milestone.completed? %>
+          <%= render "milestones/complete_stars_icon", color: milestone.color, width: 40, height: 40 %>
+        <% else %>
+          <div class="hidden sm:flex sm:items-center">
+            <%= render "stars_icon", color: milestone.color, width: 40, height: 40 %>
+          </div>
+          <div class="flex items-center sm:hidden">
+            <%= render "stars_icon", color: milestone.color %>
+          </div>
+        <% end %>
 
-      <div class="ml-2">
-        <p class="text-lg"><%= milestone.title %></p>
+        <div class="ml-2">
+          <p class="text-lg"><%= milestone.title %></p>
+        </div>
       </div>
-    </div>
-  <% end %>
+    <% end %>
 
-  <div class="mb-4 flex w-full items-center text-left">
-    <%= link_to milestone_path(milestone), class: "w-full px-1 rounded-xl hover:bg-base-300/30 active:bg-base-300/30" do %>
+  <div class="flex w-full items-center text-left">
+    <%= link_to milestone_path(milestone), class: "link_card pt-2 w-full h-20 px-1 rounded-b-xl group-hover:bg-base-300/30 group-active:bg-base-300/30" do %>
       <p class="text-xs sm:text-sm"><%= to_short_date(milestone&.start_date) %> ~ <%= to_short_date(milestone&.end_date) %></p>
 
       <!-- 詳細 -->
@@ -38,25 +41,30 @@
         <% end %>
       </div>
 
-      <% if !completed && milestone.completed_tasks_percentage == 100 && current_user?(milestone.user) %>
-        <!-- 完了ボタン -->
-        <div class="flex w-3/10 max-w-20 justify-end">
-          <%= link_to show_complete_page_milestone_path(milestone), data: { turbo_frame: "show_complete_page_modal" }, class: "btn btn-base-200 flex  w-full h-auto aspect-square flex-col items-center justify-center rounded-xl" do %>
-            <%= render "milestones/complete_stars_icon", color: milestone.color %>
-            <div class="text-xs text-base-100 whitespace-nowrap">
-              完成する
-            </div>
-          <% end %>
-        </div>
-
-      <% end %>
     <% end %>
+
+    <% if !milestone.completed? && milestone.completed_tasks_percentage == 100 && current_user?(milestone.user) %>
+      <!-- 完了ボタン -->
+      <div class="remove_hover_btn flex w-3/10 max-w-20 justify-end">
+        <%= link_to show_complete_page_milestone_path(milestone), data: { turbo_frame: "show_complete_page_modal" }, class: "btn btn-base-200 flex  w-full h-auto aspect-square flex-col items-center justify-center rounded-xl" do %>
+          <%= render "milestones/complete_stars_icon", color: milestone.color %>
+          <div class="text-xs text-base-100 whitespace-nowrap">
+            完成する
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+
+  </div>
   </div>
 
 
-  <% if !completed %>
+  <% if !milestone.completed? %>
     <!-- 進捗 -->
+    <div class="mt-4">
     <%= render "milestones/milestone_completed_percent_bar", milestone: milestone, milestone_tasks: milestone.tasks.all %>
+    </div>
   <% end %>
 
 </div>
+

--- a/app/views/milestones/_milestone.html.erb
+++ b/app/views/milestones/_milestone.html.erb
@@ -22,9 +22,10 @@
       </div>
 
       <!-- 詳細 -->
-      <div class="text-left mt-1">
+      <div class="text-left mt-2">
         <% if milestone.description.present? %>
-          <p class="text-lg"><%= milestone.description.truncate(20) %></p>
+          <p class="text-sm hidden sm:block"><%= milestone.description.truncate(30) %></p>
+          <p class="text-sm sm:hidden"><%= milestone.description.truncate(15) %></p>
         <% else %>
           <p class="text-lg">詳細はありません</p>
         <% end %>

--- a/app/views/milestones/_milestone.html.erb
+++ b/app/views/milestones/_milestone.html.erb
@@ -1,50 +1,55 @@
 <div id="milestone_<%=milestone.id%>" class="card mb-4 w-full p-4 bg-base-300/40 shadow-xl/10">
 
-  <div class="mb-4 flex w-full items-center text-left">
-    <%= link_to milestone_path(milestone), class: "w-full p-1 rounded-xl hover:bg-base-300/30 active:bg-base-300/30" do %>
-      <!-- タイトル, 日付, マーク -->
-      <div class="flex w-full">
-        <% if completed %>
-          <%= render "milestones/complete_stars_icon", color: milestone.color, width: 40, height: 40 %>
-        <% else %>
-          <div class="hidden sm:flex sm:items-center">
-            <%= render "stars_icon", color: milestone.color, width: 40, height: 40 %>
-          </div>
-          <div class="flex items-center sm:hidden">
-            <%= render "stars_icon", color: milestone.color %>
-          </div>
-        <% end %>
-
-        <div class="ml-2 w-7/10">
-          <p class="text-lg"><%= milestone.title %></p>
-          <p class="text-sm"><%= to_short_date(milestone&.start_date) %> ~ <%= to_short_date(milestone&.end_date) %></p>
+  <%= link_to milestone_path(milestone), class: "w-full mb-2 rounded-xl hover:bg-base-300/30 active:bg-base-300/30" do %>
+    <!-- タイトル, 日付, マーク -->
+    <div class="flex w-full">
+      <% if completed %>
+        <%= render "milestones/complete_stars_icon", color: milestone.color, width: 40, height: 40 %>
+      <% else %>
+        <div class="hidden sm:flex sm:items-center">
+          <%= render "stars_icon", color: milestone.color, width: 40, height: 40 %>
         </div>
+        <div class="flex items-center sm:hidden">
+          <%= render "stars_icon", color: milestone.color %>
+        </div>
+      <% end %>
+
+      <div class="ml-2">
+        <p class="text-lg"><%= milestone.title %></p>
       </div>
+    </div>
+  <% end %>
+
+  <div class="mb-4 flex w-full items-center text-left">
+    <%= link_to milestone_path(milestone), class: "w-full px-1 rounded-xl hover:bg-base-300/30 active:bg-base-300/30" do %>
+      <p class="text-xs sm:text-sm"><%= to_short_date(milestone&.start_date) %> ~ <%= to_short_date(milestone&.end_date) %></p>
 
       <!-- 詳細 -->
       <div class="text-left mt-2">
         <% if milestone.description.present? %>
-          <p class="text-sm hidden sm:block"><%= milestone.description.truncate(30) %></p>
-          <p class="text-sm sm:hidden"><%= milestone.description.truncate(15) %></p>
+          <% if milestone.tasks_completed? %>
+            <p class="text-sm"><%= milestone.description.truncate(10) %></p>
+          <% else %>
+            <p class="text-sm hidden sm:block"><%= milestone.description.truncate(30) %></p>
+            <p class="text-sm sm:hidden"><%= milestone.description.truncate(15) %></p>
+          <% end %>
         <% else %>
           <p class="text-lg">詳細はありません</p>
         <% end %>
       </div>
 
+      <% if !completed && milestone.completed_tasks_percentage == 100 && current_user?(milestone.user) %>
+        <!-- 完了ボタン -->
+        <div class="flex w-3/10 max-w-20 justify-end">
+          <%= link_to show_complete_page_milestone_path(milestone), data: { turbo_frame: "show_complete_page_modal" }, class: "btn btn-base-200 flex  w-full h-auto aspect-square flex-col items-center justify-center rounded-xl" do %>
+            <%= render "milestones/complete_stars_icon", color: milestone.color %>
+            <div class="text-xs text-base-100 whitespace-nowrap">
+              完成する
+            </div>
+          <% end %>
+        </div>
 
-    <% end %>
-
-    <% if !completed && milestone.completed_tasks_percentage == 100 && current_user?(milestone.user) %>
-      <!-- 完了ボタン -->
-      <div class="flex w-3/10 max-w-20 justify-end">
-        <%= link_to show_complete_page_milestone_path(milestone), data: { turbo_frame: "show_complete_page_modal" }, class: "btn btn-base-200 flex  w-full h-auto aspect-square flex-col items-center justify-center rounded-xl" do %>
-          <%= render "milestones/complete_stars_icon", color: milestone.color %>
-          <div class="text-xs text-base-100 whitespace-nowrap">
-            完成する
-          </div>
-        <% end %>
-      </div>
-
+      <% end %>
     <% end %>
   </div>
 

--- a/app/views/milestones/_milestones.html.erb
+++ b/app/views/milestones/_milestones.html.erb
@@ -2,6 +2,6 @@
 <!-- 星座 -->
 <div id="milestones_content" class="mx-auto">
   <% milestones.each do |milestone| %>
-    <%= render "milestones/milestone", milestone: milestone, completed: completed %>
+    <%= render "milestones/milestone", milestone: milestone %>
   <% end %>
 </div>

--- a/app/views/milestones/index.html.erb
+++ b/app/views/milestones/index.html.erb
@@ -20,7 +20,7 @@
       <div class="tabs tabs-lift w-xl">
 
         <!-- 作成中の星座 -->
-        <input type="radio" name="my_tabs" class="tab" aria-label="作成中の星座" checked="checked"/>
+        <input type="radio" name="my_tabs" class="tab" aria-label="作成中" checked="checked"/>
         <div class="tab-content border-base-300 bg-base-100 p-3">
 
           <% if current_user.guest? %>
@@ -52,25 +52,20 @@
         </div>
 
         <!-- 完成済みの星座 -->
-        <input type="radio" name="my_tabs" class="tab" aria-label="完成した星座" />
+        <input type="radio" name="my_tabs" class="tab" aria-label="完成済" />
         <div class="tab-content border-base-300 bg-base-100 p-3">
           <!-- 星座 -->
           <%= render "milestones", milestones: @completed_milestones, completed: true %>
         </div>
 
         <!-- 限定公開中の星座 -->
-        <input type="radio" name="my_tabs" class="tab" aria-label="限定公開中の星座"/>
+        <input type="radio" name="my_tabs" class="tab" aria-label="限定公開"/>
         <div class="tab-content border-base-300 bg-base-100 p-3">
 
 
           <!-- 星座 -->
           <% @sharing_milestones.each do |milestone| %>
-            <%= link_to share_milestone_path(milestone), class: "card mb-4 w-full p-4 bg-base-300/40 shadow-xl/10" do %>
-              <div class="mb-4 flex w-full items-center text-left">
-                <%= milestone.title %>
-                <%= milestone.created_at.to_date %>
-              </div>
-            <% end %>
+            <%= render "limited_sharing_milestones/milestone", milestone: milestone %>
           <% end %>
 
         </div>

--- a/app/views/milestones/index.html.erb
+++ b/app/views/milestones/index.html.erb
@@ -58,6 +58,22 @@
           <%= render "milestones", milestones: @completed_milestones, completed: true %>
         </div>
 
+        <input type="radio" name="my_tabs" class="tab" aria-label="限定公開中の星座" checked="checked"/>
+        <div class="tab-content border-base-300 bg-base-100 p-3">
+
+
+          <!-- 星座 -->
+          <% @sharing_milestones.each do |milestone| %>
+            <%= link_to share_milestone_path(milestone), class: "card mb-4 w-full p-4 bg-base-300/40 shadow-xl/10" do %>
+              <div class="mb-4 flex w-full items-center text-left">
+                <%= milestone.title %>
+                <%= milestone.created_at.to_date %>
+              </div>
+            <% end %>
+          <% end %>
+
+        </div>
+
       </div>
     </div>
   </div>

--- a/app/views/milestones/index.html.erb
+++ b/app/views/milestones/index.html.erb
@@ -58,7 +58,8 @@
           <%= render "milestones", milestones: @completed_milestones, completed: true %>
         </div>
 
-        <input type="radio" name="my_tabs" class="tab" aria-label="限定公開中の星座" checked="checked"/>
+        <!-- 限定公開中の星座 -->
+        <input type="radio" name="my_tabs" class="tab" aria-label="限定公開中の星座"/>
         <div class="tab-content border-base-300 bg-base-100 p-3">
 
 

--- a/app/views/milestones/index.html.erb
+++ b/app/views/milestones/index.html.erb
@@ -48,14 +48,14 @@
           <% end %>
 
           <!-- 星座 -->
-          <%= render "milestones", milestones: @not_completed_milestones, completed: false %>
+          <%= render "milestones", milestones: @not_completed_milestones %>
         </div>
 
         <!-- 完成済みの星座 -->
         <input type="radio" name="my_tabs" class="tab" aria-label="完成済" />
         <div class="tab-content border-base-300 bg-base-100 p-3">
           <!-- 星座 -->
-          <%= render "milestones", milestones: @completed_milestones, completed: true %>
+          <%= render "milestones", milestones: @completed_milestones %>
         </div>
 
         <!-- 限定公開中の星座 -->

--- a/app/views/milestones/show.html.erb
+++ b/app/views/milestones/show.html.erb
@@ -151,135 +151,143 @@
     <% if current_user?(@milestone.user) %>
 
       <!-- 編集・削除ボタン -->
-      <div>
-        <div class="flex h-12 w-full justify-center text-neutral mb-5">
-          <% if current_user.guest? %>
-            <div class="tooltip" data-tip="ゲストユーザーは使用できません">
-              <div class="btn btn-disabled mr-5 h-12 w-25 md:w-42">
-                削除
-              </div>
-            </div>
-          <% else %>
-            <div class="btn btn-error mr-5 h-12 w-25 md:w-42" onclick="delete_confirm_modal.showModal()">
+      <div class="flex h-12 w-full justify-center text-neutral mb-8">
+        <% if current_user.guest? %>
+          <div class="tooltip" data-tip="ゲストユーザーは使用できません">
+            <div class="btn btn-disabled mr-5 h-12 w-25 md:w-42">
               削除
-            </div>
-          <% end %>
-          <button class="btn btn-accent h-12 w-25 md:w-42" onclick="milestones_edit_modal.showModal()">
-            編集
-          </button>
-        </div>
-
-        <!-- copyボタン -->
-        <% if @milestone.user.guest? %>
-          <div class="relative left-4 btn bg-transparent text-base-200 hover:cursor-default">
-            <div class="tooltip" data-tip="ゲストユーザーは使用できません">
-              <span class="material-symbols-outlined">
-                content_copy
-              </span>
             </div>
           </div>
         <% else %>
-          <%= link_to milestones_copy_path(@milestone), data: { turbo_frame: "milestones_copy_modal"}, class: "relative left-4 btn bg-base-300 hover:bg-base-200/10 text-base-200" do %>
-            <div class="tooltip" data-tip="タスクをコピーする">
-              <span id="copy_icon_<%=@milestone.id%>" class="material-symbols-outlined">
-                content_copy
+          <div class="btn btn-error mr-5 h-12 w-25 md:w-42" onclick="delete_confirm_modal.showModal()">
+            削除
+          </div>
+        <% end %>
+        <button class="btn btn-accent h-12 w-25 md:w-42" onclick="milestones_edit_modal.showModal()">
+          編集
+        </button>
+      </div>
+
+      <!-- タスクのコピー・共有ボタン -->
+      <div class="flex justify-center items-center">
+        <!-- shareボタン -->
+        <div class="mr-20 relative">
+          <% if @milestone.user.guest? %>
+            <div class="btn bg-transparent text-base-200 hover:cursor-default">
+              <div class="tooltip" data-tip="ゲストユーザーは使用できません">
+                <span class="material-symbols-outlined">
+                  share
+                </span>
+              </div>
+            </div>
+          <% else %>
+            <button
+              class="btn bg-base-300 hover:bg-base-200/10 text-base-200"
+              onclick="share_confirm_modal.showModal()"
+              >
+              <div class="tooltip" data-tip="限定公開URLを発行する">
+                <span class="material-symbols-outlined">
+                  add_link
+                </span>
+              </div>
+            </button>
+          <% end %>
+
+          <div class="dropdown dropdown-top dropdown-center top-4 absolute left-30">
+            <div tabindex="0" role="button" class="btn btn-circle btn-ghost btn-xs text-info">
+              <span class="material-symbols-outlined text-base-200">
+                help
               </span>
             </div>
-          <% end %>
-        <% end %>
-        <div class="dropdown dropdown-top dropdown-center left-4 top-2">
-          <div tabindex="0" role="button" class="btn btn-circle btn-ghost btn-xs text-info">
-            <span class="material-symbols-outlined text-base-200">
-              help
-            </span>
+            <div
+              tabindex="0"
+              class="card dropdown-content bg-base-100 rounded-box z-1 w-70 mr-10 shadow-xl border-1">
+              <div tabindex="0" class="card-body text-sm px-1">
+                <div class="text-center">
+
+                  <p class="mb-2">URLを知っている人だけが<br>
+                  閲覧できる星座の共有ページを<br>
+                  作成します。</p>
+                  <p class="">URLをコピーして共有してください。<br>
+
+                  <div class="divider"></div>
+                  <p class="">作成時点での状況を保持します。</p>
+
+                  <div class="divider"></div>
+
+                  <p class="mb-2">共有取り消しボタンを推すまで、<br>公開され続けます。</p>
+                  <p class="">共有取り消しボタンは、<br>公開ページ内に、星座の所有者のみに表示されます。</p>
+
+                </div>
+              </div>
+            </div>
           </div>
-          <div
-            tabindex="0"
-            class="card dropdown-content bg-base-100 rounded-box z-1 w-70 mr-10 shadow-xl border-1">
-            <div tabindex="0" class="card-body text-sm px-1">
-              <div class="text-center">
-                <p class="mb-2">始点となる日を設定して、<br>
-                星座をコピーします。</p>
-                <p class="mb-2">始点を設定しない場合は、<br>
-                そのままコピーします。</p>
 
-                <div class="divider"></div>
+        </div>
 
-                <p class="mb-2">始点を設定した場合、</p>
-                <p class="mb-2">・開始日または終了日を始点の日に<br>
-                設定してコピーします。</p>
+        <div class="relative">
+          <!-- copyボタン -->
+          <% if @milestone.user.guest? %>
+            <div class="btn bg-transparent text-base-200 hover:cursor-default">
+              <div class="tooltip" data-tip="ゲストユーザーは使用できません">
+                <span class="material-symbols-outlined">
+                  content_copy
+                </span>
+              </div>
+            </div>
+          <% else %>
+            <%= link_to milestones_copy_path(@milestone), data: { turbo_frame: "milestones_copy_modal"}, class: "btn bg-base-300 hover:bg-base-200/10 text-base-200" do %>
+              <div class="tooltip" data-tip="タスクをコピーする">
+                <span id="copy_icon_<%=@milestone.id%>" class="material-symbols-outlined">
+                  content_copy
+                </span>
+              </div>
+            <% end %>
+          <% end %>
 
-                <div class="divider"></div>
-                <p class="mb-4">開始日も終了日も無い星座の場合は<br>
-                日付を設定せずにコピーします。
-                </p>
+          <div class="dropdown dropdown-top dropdown-center top-4 absolute left-30">
+            <div tabindex="0" role="button" class="btn btn-circle btn-ghost btn-xs text-info">
+              <span class="material-symbols-outlined text-base-200">
+                help
+              </span>
+            </div>
+            <div
+              tabindex="0"
+              class="card dropdown-content bg-base-100 rounded-box z-1 w-70 mr-10 shadow-xl border-1">
+              <div tabindex="0" class="card-body text-sm px-1">
+                <div class="text-center">
+                  <p class="mb-2">始点となる日を設定して、<br>
+                  星座をコピーします。</p>
+                  <p class="mb-2">始点を設定しない場合は、<br>
+                  そのままコピーします。</p>
 
-                <div class="divider"></div>
-                <p class="mb-2">紐づくタスクは<br>
-                <p class="mb-2">・星座に日付がある場合は<br>
-                それを基準としてコピーします。</p>
-                <p class="mb-2">・星座に日付が無い場合は、<br>
-                タスクの中で一番早い日付を基準に
-                <br>コピーします。</p>
+                  <div class="divider"></div>
 
+                  <p class="mb-2">始点を設定した場合、</p>
+                  <p class="mb-2">・開始日または終了日を始点の日に<br>
+                  設定してコピーします。</p>
+
+                  <div class="divider"></div>
+                  <p class="mb-4">開始日も終了日も無い星座の場合は<br>
+                  日付を設定せずにコピーします。
+                  </p>
+
+                  <div class="divider"></div>
+                  <p class="mb-2">紐づくタスクは<br>
+                  <p class="mb-2">・星座に日付がある場合は<br>
+                  それを基準としてコピーします。</p>
+                  <p class="mb-2">・星座に日付が無い場合は、<br>
+                  タスクの中で一番早い日付を基準に
+                  <br>コピーします。</p>
+
+                </div>
               </div>
             </div>
           </div>
         </div>
+
+
       </div>
-
-      <!-- shareボタン -->
-      <% if @milestone.user.guest? %>
-        <div class="relative left-4 btn bg-transparent text-base-200 hover:cursor-default">
-          <div class="tooltip" data-tip="ゲストユーザーは使用できません">
-            <span class="material-symbols-outlined">
-              share
-            </span>
-          </div>
-        </div>
-      <% else %>
-        <button
-          class="relative left-4 btn bg-base-300 hover:bg-base-200/10 text-base-200"
-          onclick="share_confirm_modal.showModal()"
-          >
-          <div class="tooltip" data-tip="他のユーザーと共有する">
-            <span class="material-symbols-outlined">
-              share
-            </span>
-          </div>
-        </button>
-      <% end %>
-
-      <div class="dropdown dropdown-top dropdown-center left-4">
-        <div tabindex="0" role="button" class="btn btn-circle btn-ghost btn-xs text-info">
-          <span class="material-symbols-outlined text-base-200">
-            help
-          </span>
-        </div>
-        <div
-          tabindex="0"
-          class="card dropdown-content bg-base-100 rounded-box z-1 w-70 mr-10 shadow-xl border-1">
-          <div tabindex="0" class="card-body text-sm px-1">
-            <div class="text-center">
-
-              <p class="mb-2">URLを知っている人だけが<br>
-              閲覧できる星座の共有ページを<br>
-              作成します。</p>
-              <p class="">URLをコピーして共有してください。<br>
-
-              <div class="divider"></div>
-              <p class="">作成時点での状況を保持します。</p>
-
-              <div class="divider"></div>
-
-              <p class="mb-2">共有取り消しボタンを推すまで、<br>公開され続けます。</p>
-              <p class="">共有取り消しボタンは、<br>公開ページ内に、星座の所有者のみに表示されます。</p>
-
-            </div>
-          </div>
-        </div>
-      </div>
-
     <% end %>
 
     <!-- タスクの表示部分 -->

--- a/app/views/milestones/show.html.erb
+++ b/app/views/milestones/show.html.erb
@@ -16,9 +16,9 @@
         <%= "#{@milestone.title} 座" %>
       </div>
       <div class="mx-auto flex justify-center items-center rounded-full h-52 w-52 bg-base-200">
-      <%= link_to  milestone_constellation_url(@milestone) do %>
-        <%= image_tag "#{@milestone.constellation.image_name}.webp", class: "h-50 w-50 mask mask-circle", oncontextmenu: "return false;", onselectstart: "return false;", onmousedown: "return false;" %>
-      <% end %>
+        <%= link_to  milestone_constellation_url(@milestone) do %>
+          <%= image_tag "#{@milestone.constellation.image_name}.webp", class: "h-50 w-50 mask mask-circle", oncontextmenu: "return false;", onselectstart: "return false;", onmousedown: "return false;" %>
+        <% end %>
       </div>
       <%= link_to  milestone_constellation_url(@milestone) do %>
         <p class="text-xs text-base-200 link">画像：<%= @milestone.constellation.name %></p>
@@ -57,7 +57,7 @@
         <div class="flex h-35 w-full justify-center text-neutral">
           <div class="flex w-xl justify-between p-3">
             <div class="card flex h-full w-2/5 flex-col justify-center bg-primary p-2">
-                <%= @milestone.start_date&.year %>
+              <%= @milestone.start_date&.year %>
               <div class="w-full text-xl">
                 <%= to_short_date(@milestone.start_date) %>
               </div>
@@ -149,41 +149,108 @@
 
     <!-- button -->
     <% if current_user?(@milestone.user) %>
-      <div class="flex h-12 w-full justify-center text-neutral">
-        <% if current_user.guest? %>
-          <div class="tooltip" data-tip="ゲストユーザーは使用できません">
-            <div class="btn btn-disabled mr-5 h-12 w-25 md:w-42">
+
+      <!-- 編集・削除ボタン -->
+      <div>
+        <div class="flex h-12 w-full justify-center text-neutral mb-5">
+          <% if current_user.guest? %>
+            <div class="tooltip" data-tip="ゲストユーザーは使用できません">
+              <div class="btn btn-disabled mr-5 h-12 w-25 md:w-42">
+                削除
+              </div>
+            </div>
+          <% else %>
+            <div class="btn btn-error mr-5 h-12 w-25 md:w-42" onclick="delete_confirm_modal.showModal()">
               削除
+            </div>
+          <% end %>
+          <button class="btn btn-accent h-12 w-25 md:w-42" onclick="milestones_edit_modal.showModal()">
+            編集
+          </button>
+        </div>
+
+        <!-- copyボタン -->
+        <% if @milestone.user.guest? %>
+          <div class="relative left-4 btn bg-transparent text-base-200 hover:cursor-default">
+            <div class="tooltip" data-tip="ゲストユーザーは使用できません">
+              <span class="material-symbols-outlined">
+                content_copy
+              </span>
             </div>
           </div>
         <% else %>
-          <div class="btn btn-error mr-5 h-12 w-25 md:w-42" onclick="delete_confirm_modal.showModal()">
-            削除
-          </div>
+          <%= link_to milestones_copy_path(@milestone), data: { turbo_frame: "milestones_copy_modal"}, class: "relative left-4 btn bg-base-300 hover:bg-base-200/10 text-base-200" do %>
+            <div class="tooltip" data-tip="タスクをコピーする">
+              <span id="copy_icon_<%=@milestone.id%>" class="material-symbols-outlined">
+                content_copy
+              </span>
+            </div>
+          <% end %>
         <% end %>
-        <button class="btn btn-accent h-12 w-25 md:w-42" onclick="milestones_edit_modal.showModal()">
-          編集
-        </button>
+        <div class="dropdown dropdown-top dropdown-center left-4 top-2">
+          <div tabindex="0" role="button" class="btn btn-circle btn-ghost btn-xs text-info">
+            <span class="material-symbols-outlined text-base-200">
+              help
+            </span>
+          </div>
+          <div
+            tabindex="0"
+            class="card dropdown-content bg-base-100 rounded-box z-1 w-70 mr-10 shadow-xl border-1">
+            <div tabindex="0" class="card-body text-sm px-1">
+              <div class="text-center">
+                <p class="mb-2">始点となる日を設定して、<br>
+                星座をコピーします。</p>
+                <p class="mb-2">始点を設定しない場合は、<br>
+                そのままコピーします。</p>
+
+                <div class="divider"></div>
+
+                <p class="mb-2">始点を設定した場合、</p>
+                <p class="mb-2">・開始日または終了日を始点の日に<br>
+                設定してコピーします。</p>
+
+                <div class="divider"></div>
+                <p class="mb-4">開始日も終了日も無い星座の場合は<br>
+                日付を設定せずにコピーします。
+                </p>
+
+                <div class="divider"></div>
+                <p class="mb-2">紐づくタスクは<br>
+                <p class="mb-2">・星座に日付がある場合は<br>
+                それを基準としてコピーします。</p>
+                <p class="mb-2">・星座に日付が無い場合は、<br>
+                タスクの中で一番早い日付を基準に
+                <br>コピーします。</p>
+
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
 
+      <!-- shareボタン -->
       <% if @milestone.user.guest? %>
         <div class="relative left-4 btn bg-transparent text-base-200 hover:cursor-default">
           <div class="tooltip" data-tip="ゲストユーザーは使用できません">
             <span class="material-symbols-outlined">
-              content_copy
+              share
             </span>
           </div>
         </div>
       <% else %>
-        <%= link_to milestones_copy_path(@milestone), data: { turbo_frame: "milestones_copy_modal"}, class: "relative left-4 btn bg-base-300 hover:bg-base-200/10 text-base-200" do %>
-          <div class="tooltip" data-tip="タスクをコピーする">
-            <span id="copy_icon_<%=@milestone.id%>" class="material-symbols-outlined">
-              content_copy
+        <button
+          class="relative left-4 btn bg-base-300 hover:bg-base-200/10 text-base-200"
+          onclick="share_confirm_modal.showModal()"
+          >
+          <div class="tooltip" data-tip="他のユーザーと共有する">
+            <span class="material-symbols-outlined">
+              share
             </span>
           </div>
-        <% end %>
+        </button>
       <% end %>
-      <div class="dropdown dropdown-top dropdown-center relative left-4">
+
+      <div class="dropdown dropdown-top dropdown-center left-4">
         <div tabindex="0" role="button" class="btn btn-circle btn-ghost btn-xs text-info">
           <span class="material-symbols-outlined text-base-200">
             help
@@ -194,42 +261,24 @@
           class="card dropdown-content bg-base-100 rounded-box z-1 w-70 mr-10 shadow-xl border-1">
           <div tabindex="0" class="card-body text-sm px-1">
             <div class="text-center">
-              <p class="mb-2">始点を設定しない場合は、<br>
-              そのままコピーします。</p>
+
+              <p class="mb-2">URLを知っている人だけが<br>
+              閲覧できる星座の共有ページを<br>
+              作成します。</p>
+              <p class="">URLをコピーして共有してください。<br>
+
+              <div class="divider"></div>
+              <p class="">作成時点での状況を保持します。</p>
 
               <div class="divider"></div>
 
-              <p class="mb-2">始点を指定した場合、</p>
-              <p class="mb-2">・開始日または終了日を始点の日に<br>
-              設定してコピーします。</p>
-
-              <div class="divider"></div>
-              <p class="mb-4">開始日も終了日も無い星座の場合は<br>
-              日付を設定せずにコピーします。
-              </p>
-
-              <div class="divider"></div>
-              <p class="mb-2">紐づくタスクは<br>
-              <p class="mb-2">・星座に日付がある場合は<br>
-              それを基準としてコピーします。</p>
-              <p class="mb-2">・星座に日付が無い場合は、<br>
-              タスクの内の一番早い日付を基準に
-              <br>コピーします。</p>
+              <p class="mb-2">共有取り消しボタンを推すまで、<br>公開され続けます。</p>
+              <p class="">共有取り消しボタンは、<br>公開ページ内に、星座の所有者のみに表示されます。</p>
 
             </div>
           </div>
         </div>
       </div>
-
-      <%= button_to limited_sharing_milestones_path(id: @milestone.id),
-        method: :post,
-        class: "relative left-4 btn bg-base-300 hover:bg-base-200/10 text-base-200" do %>
-        <div class="tooltip" data-tip="他のユーザーと共有する">
-          <span class="material-symbols-outlined">
-            share
-          </span>
-        </div>
-      <% end %>
 
     <% end %>
 
@@ -269,7 +318,7 @@
                 milestone_widths: @milestone_widths, 
                 milestone_lefts: @milestone_lefts, 
                 chart_total_width: @chart_total_width %>
-          </div>
+            </div>
           </div>
         <% end %>
 
@@ -291,6 +340,7 @@
   <%= turbo_frame_tag "tasks_new_modal" %>
   <%= turbo_frame_tag "tasks_copy_modal" %>
   <%= turbo_frame_tag "milestones_copy_modal" %>
+  <%= render 'limited_sharing_milestones/share_confirm_modal' %>
 <% end %>
 
 <%= turbo_frame_tag "milestone_show_modal" %>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -3,7 +3,7 @@
 
   <div class="h-[94dvh] flex items-center justify-center max-sm:w-full intersect:motion-ease-spring-bouncier intersect:motion-preset-slide-down intersect-once">
     <div class="flex flex-col items-center">
-      <%= image_tag 'icon-512x512.png', class: 'mb-5 h-20 w-20 md:h-30 md:w-30' %>
+      <%= image_tag 'icon-512x512.png', class: 'relative z-10 mb-5 h-20 w-20 md:h-30 md:w-30' %>
       <p class="text-5xl md:text-6xl text-center [writing-mode:vertical-rl] [text-orientation:upright]">星にタスクを</p>
     </div>
   </div>
@@ -186,7 +186,7 @@
 
 </div>
 
-<footer class="footer footer-center footer-horizontal rounded bg-base-300 p-10 text-base-content">
+<footer class="footer footer-center relative z-10 footer-horizontal rounded bg-base-300 p-10 text-base-content">
   <nav class="grid grid-flow-col gap-4">
     <a class="link link-hover" href="https://docs.google.com/forms/d/e/1FAIpQLScH-P7JBj_jwoFrQuMeJI_eQJwutS7p57h8nEbdWGgK30sXZQ/viewform">お問い合わせ</a>
     <a class="link link-hover" href="/terms_of_service">利用規約</a>

--- a/app/views/tasks/_progress_button.html.erb
+++ b/app/views/tasks/_progress_button.html.erb
@@ -1,5 +1,5 @@
 <div id="progress_button_<%=task.id%>">
-  <% if !(task.class == LimitedSharingTask) && current_user?(task.user) %>
+  <% if !(task.is_a?(LimitedSharingTask)) && current_user?(task.user) %>
     <%= button_to update_progress_task_path(task), method: :patch, form: { data: { turbo: true } }, class: "btn btn-base-200 flex w-full h-auto aspect-square flex-col items-center justify-center rounded-xl" do %>
       <% if task.progress == "not_started" %>
         <div class="text-xs text-base-100 whitespace-nowrap">

--- a/app/views/tasks/_progress_button.html.erb
+++ b/app/views/tasks/_progress_button.html.erb
@@ -1,4 +1,4 @@
-<div id="progress_button_<%=task.id%>" class="flex w-3/10 max-w-20 justify-end">
+<div id="progress_button_<%=task.id%>">
   <% if !(task.class == LimitedSharingTask) && current_user?(task.user) %>
     <%= button_to update_progress_task_path(task), method: :patch, form: { data: { turbo: true } }, class: "btn btn-base-200 flex w-full h-auto aspect-square flex-col items-center justify-center rounded-xl" do %>
       <% if task.progress == "not_started" %>
@@ -19,7 +19,7 @@
       <% end %>
     <% end %>
   <% else %>
-    <div class= "py-2 px-6 bg-base-200 flex w-full h-auto aspect-square flex-col items-center text-center justify-center rounded-xl">
+    <div class= "bg-base-200 flex w-full h-20 aspect-square flex-col items-center text-center justify-center rounded-xl">
       <% if task.progress == "not_started" %>
         <div class="text-xs text-base-100 whitespace-nowrap">
           <%= render "tasks/not_started_icon", color: task.milestone&.color %>

--- a/app/views/tasks/_progress_button.html.erb
+++ b/app/views/tasks/_progress_button.html.erb
@@ -19,7 +19,7 @@
       <% end %>
     <% end %>
   <% else %>
-    <div class= "bg-base-200 flex w-full h-auto aspect-square flex-col items-center text-center justify-center rounded-xl">
+    <div class= "py-2 px-6 bg-base-200 flex w-full h-auto aspect-square flex-col items-center text-center justify-center rounded-xl">
       <% if task.progress == "not_started" %>
         <div class="text-xs text-base-100 whitespace-nowrap">
           <%= render "tasks/not_started_icon", color: task.milestone&.color %>

--- a/app/views/tasks/_progress_button.html.erb
+++ b/app/views/tasks/_progress_button.html.erb
@@ -1,23 +1,23 @@
-  <div id="progress_button_<%=task.id%>" class="flex w-3/10 max-w-20 justify-end">
-  <% if !task.class == "LimitedSharingTask" && current_user?(task.user) %>
-  <%= button_to update_progress_task_path(task), method: :patch, form: { data: { turbo: true } }, class: "btn btn-base-200 flex w-full h-auto aspect-square flex-col items-center justify-center rounded-xl" do %>
-    <% if task.progress == "not_started" %>
-      <div class="text-xs text-base-100 whitespace-nowrap">
-      <%= render "tasks/not_started_icon", color: task.milestone&.color %>
-      未着手
-      </div>
-    <% elsif task.progress == "in_progress" %>
-      <div class="text-xs text-base-100 whitespace-nowrap">
-      <%= render "tasks/in_progress_icon", color: task.milestone&.color %>
-      進行中
-      </div>
-    <% elsif task.progress == "completed" %>
-      <div class="text-xs text-base-100 whitespace-nowrap">
-      <%= render "tasks/completed_icon", color: task.milestone&.color %>
-      完了
-      </div>
+<div id="progress_button_<%=task.id%>" class="flex w-3/10 max-w-20 justify-end">
+  <% if !(task.class == LimitedSharingTask) && current_user?(task.user) %>
+    <%= button_to update_progress_task_path(task), method: :patch, form: { data: { turbo: true } }, class: "btn btn-base-200 flex w-full h-auto aspect-square flex-col items-center justify-center rounded-xl" do %>
+      <% if task.progress == "not_started" %>
+        <div class="text-xs text-base-100 whitespace-nowrap">
+          <%= render "tasks/not_started_icon", color: task.milestone&.color %>
+          未着手
+        </div>
+      <% elsif task.progress == "in_progress" %>
+        <div class="text-xs text-base-100 whitespace-nowrap">
+          <%= render "tasks/in_progress_icon", color: task.milestone&.color %>
+          進行中
+        </div>
+      <% elsif task.progress == "completed" %>
+        <div class="text-xs text-base-100 whitespace-nowrap">
+          <%= render "tasks/completed_icon", color: task.milestone&.color %>
+          完了
+        </div>
+      <% end %>
     <% end %>
-  <% end %>
   <% else %>
     <div class= "bg-base-200 flex w-full h-auto aspect-square flex-col items-center text-center justify-center rounded-xl">
       <% if task.progress == "not_started" %>
@@ -38,4 +38,4 @@
       <% end %>
     </div>
   <% end %>
-  </div>
+</div>

--- a/app/views/tasks/_progress_button.html.erb
+++ b/app/views/tasks/_progress_button.html.erb
@@ -1,5 +1,5 @@
   <div id="progress_button_<%=task.id%>" class="flex w-3/10 max-w-20 justify-end">
-  <% if current_user?(task.user) %>
+  <% if !task.class == "LimitedSharingTask" && current_user?(task.user) %>
   <%= button_to update_progress_task_path(task), method: :patch, form: { data: { turbo: true } }, class: "btn btn-base-200 flex w-full h-auto aspect-square flex-col items-center justify-center rounded-xl" do %>
     <% if task.progress == "not_started" %>
       <div class="text-xs text-base-100 whitespace-nowrap">

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -19,7 +19,7 @@
 
   <div class="flex w-full items-center text-left">
     <button 
-      class="w-full p-1 rounded-xl hover:bg-base-300/30 active:bg-base-300/30 hover:cursor-pointer text-start"
+      class="w-full px-1 rounded-xl hover:bg-base-300/30 active:bg-base-300/30 hover:cursor-pointer text-start"
       onclick="tasks_show_modal_<%=task.id%>_target.showModal()"
       >
       <div>
@@ -32,7 +32,7 @@
           <p class="text-sm hidden sm:block"><%= task.description.truncate(30) %></p>
           <p class="text-sm sm:hidden"><%= task.description.truncate(12) %></p>
         <% else %>
-          <p class="text-lg">詳細はありません</p>
+          <p class="text-sm">詳細はありません</p>
         <% end %>
       </div>
     </button>

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -1,8 +1,10 @@
-<div id="task_<%=task.id%>" class="card mb-4 w-full p-4 bg-base-300/40 shadow-xl/10">
+<div id="task_<%= task.id %>" class="card mb-4 w-full p-4 bg-base-300/40 shadow-xl/10">
 
-
+  <%# groupにhoverするとbgが変わる %>
+  <%# remove_hover_btn要素にhoverするとjsによってlink_card要素のgroup-hover:bg-base-300/30が取り除かれる %>
+  <div class="group">
     <button 
-      class="w-full pb-2 rounded-xl hover:bg-base-300/30 active:bg-base-300/30 hover:cursor-pointer text-start"
+      class="link_card w-full pb-2 rounded-t-xl group-hover:bg-base-300/30 group-active:bg-base-300/30 hover:cursor-pointer text-start"
       onclick="tasks_show_modal_<%=task.id%>_target.showModal()"
       >
       <!-- タイトル, 日付, マーク -->
@@ -17,9 +19,9 @@
       </div>
     </button>
 
-  <div class="flex w-full items-center text-left">
+  <div class="flex w-full items-center">
     <button 
-      class="w-full px-1 rounded-xl hover:bg-base-300/30 active:bg-base-300/30 hover:cursor-pointer text-start"
+      class="link_card w-full h-20 pt-2 px-1 rounded-b-xl group-hover:bg-base-300/30 group-active:bg-base-300/30 hover:cursor-pointer text-start"
       onclick="tasks_show_modal_<%=task.id%>_target.showModal()"
       >
       <div>
@@ -27,7 +29,7 @@
       </div>
 
       <!-- 詳細 -->
-      <div class="text-left mt-2">
+      <div class="mt-2">
         <% if task.description.present? %>
           <p class="text-sm hidden sm:block"><%= task.description.truncate(30) %></p>
           <p class="text-sm sm:hidden"><%= task.description.truncate(12) %></p>
@@ -39,8 +41,11 @@
 
     <!-- progressボタン -->
     <% unless task.milestone_completed? %>
+      <div class="remove_hover_btn flex w-3/10 max-w-20 justify-end">
       <%= render "tasks/progress_button", task: task %>
+      </div>
     <% end %>
+  </div>
   </div>
 
 

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -1,9 +1,8 @@
 <div id="task_<%=task.id%>" class="card mb-4 w-full p-4 bg-base-300/40 shadow-xl/10">
 
-  <div class="flex w-full items-center text-left">
 
     <button 
-      class="w-full p-1 rounded-xl hover:bg-base-300/30 active:bg-base-300/30 hover:cursor-pointer text-start"
+      class="w-full pb-2 rounded-xl hover:bg-base-300/30 active:bg-base-300/30 hover:cursor-pointer text-start"
       onclick="tasks_show_modal_<%=task.id%>_target.showModal()"
       >
       <!-- タイトル, 日付, マーク -->
@@ -14,26 +13,35 @@
 
         <div class="ml-2 w-7/10">
           <p class="text-lg"><%= task.title %></p>
-
-          <p class="text-sm"><%= to_short_date(task.start_date) %> ~ <%= to_short_date(task.end_date) %></p>
         </div>
+      </div>
+    </button>
+
+  <div class="flex w-full items-center text-left">
+    <button 
+      class="w-full p-1 rounded-xl hover:bg-base-300/30 active:bg-base-300/30 hover:cursor-pointer text-start"
+      onclick="tasks_show_modal_<%=task.id%>_target.showModal()"
+      >
+      <div>
+        <p class="text-xs sm:text-sm"><%= to_short_date(task.start_date) %> ~ <%= to_short_date(task.end_date) %></p>
       </div>
 
       <!-- 詳細 -->
-      <div class="text-left mt-1">
+      <div class="text-left mt-2">
         <% if task.description.present? %>
-          <p class="text-lg"><%= task.description.truncate(20) %></p>
+          <p class="text-sm hidden sm:block"><%= task.description.truncate(30) %></p>
+          <p class="text-sm sm:hidden"><%= task.description.truncate(12) %></p>
         <% else %>
           <p class="text-lg">詳細はありません</p>
         <% end %>
       </div>
-
     </button>
 
-      <!-- progressボタン -->
-      <% unless task.milestone_completed? %>
-        <%= render "tasks/progress_button", task: task %>
-      <% end %>
+    <!-- progressボタン -->
+    <% unless task.milestone_completed? %>
+      <%= render "tasks/progress_button", task: task %>
+    <% end %>
   </div>
+
 
 </div>

--- a/app/views/tasks/_tasks_show_modal_content.html.erb
+++ b/app/views/tasks/_tasks_show_modal_content.html.erb
@@ -96,7 +96,9 @@
           <% end %>
 
           <!-- アクションボタン -->
-          <% if current_user&.guest? && current_user?(@task.user) %>
+          <% if @task.class == LimitedSharingTask %>
+            <!-- not content -->
+          <% elsif current_user&.guest? && current_user?(@task.user) %>
             <div class="flex h-12 w-full mt-10 justify-center text-neutral">
               <div class="tooltip" data-tip="ゲストユーザーは使用できません">
                 <button class="btn btn-disabled h-12 w-25 mr-5 md:w-42">削除</button>

--- a/app/views/tasks/_tasks_show_modal_content.html.erb
+++ b/app/views/tasks/_tasks_show_modal_content.html.erb
@@ -96,7 +96,7 @@
           <% end %>
 
           <!-- アクションボタン -->
-          <% if @task.class == LimitedSharingTask %>
+          <% if @task.is_a?(LimitedSharingTask) %>
             <!-- not content -->
           <% elsif current_user&.guest? && current_user?(@task.user) %>
             <div class="flex h-12 w-full mt-10 justify-center text-neutral">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
 
   resources :tasks do
     patch "update_progress", on: :member
+    get "share" => "limited_sharing_tasks#show", on: :member
   end
   namespace :tasks do
     resources :copies, only: [:show, :create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
     resources :copies, only: [:show, :create]
   end
 
+  resources :limited_sharing_milestones, only: [:show, :create, :destroy]
+
   get "gantt_chart" => "gantt_chart#show", as: :gantt_chart
   get "gantt_chart_milestone/:id" => "gantt_chart#milestone_show", as: :gantt_chart_milestone_show
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,12 +11,13 @@ Rails.application.routes.draw do
   resources :milestones do
     get "show_complete_page", on: :member
     patch "complete", on: :member
+    get "share" => "limited_sharing_milestones#show", on: :member
   end
   namespace :milestones do
     resources :copies, only: [:show, :create]
   end
 
-  resources :limited_sharing_milestones, only: [:show, :create, :destroy]
+  resources :limited_sharing_milestones, only: [:create, :destroy]
 
   get "gantt_chart" => "gantt_chart#show", as: :gantt_chart
   get "gantt_chart_milestone/:id" => "gantt_chart#milestone_show", as: :gantt_chart_milestone_show

--- a/db/migrate/20250509110953_add_user_id_to_limited_sharing_task.rb
+++ b/db/migrate/20250509110953_add_user_id_to_limited_sharing_task.rb
@@ -1,0 +1,5 @@
+class AddUserIdToLimitedSharingTask < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :limited_sharing_tasks, :user, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_09_033937) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_09_110953) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -47,7 +47,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_09_033937) do
     t.string "limited_sharing_milestone_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.index ["limited_sharing_milestone_id"], name: "index_limited_sharing_tasks_on_limited_sharing_milestone_id"
+    t.index ["user_id"], name: "index_limited_sharing_tasks_on_user_id"
   end
 
   create_table "milestones", force: :cascade do |t|
@@ -106,6 +108,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_09_033937) do
   add_foreign_key "limited_sharing_milestones", "constellations"
   add_foreign_key "limited_sharing_milestones", "users"
   add_foreign_key "limited_sharing_tasks", "limited_sharing_milestones"
+  add_foreign_key "limited_sharing_tasks", "users"
   add_foreign_key "milestones", "constellations"
   add_foreign_key "milestones", "users"
   add_foreign_key "tasks", "milestones"


### PR DESCRIPTION
<!-- github copilot レビューは日本語でお願いします -->
# 概要

<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->

限定公開機能を実装しました。
限定公開ボタンを押すと、確認モーダルが出現し、公開を押すと公開されます。
urlを知っている人であれば、誰でも閲覧できるタスクを作成することができます。

その他、uiの一部変更を行いました。

# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイントです -->

- app
  - controllers
    - limited_sharing_milestones_controller.rb 106, 0
      - 星座限定公開用のコントローラ
      - show, create, destroyが存在する
      - 生成はmilestone/showからcreateにアクセスし、そのidからbase_milestoneを取得し、その値をlimited_sharing_milestoneにコピーしてsaveする
      - showにはチャートを表示するため、prepare_chartメソッドを配置し、必要な値を取得している
    - limited_sharing_tasks_controller.rb 11, 0
      - 限定公開星座に紐づくtask用コントローラで、showだけ定義
    - milestones_controller.rb 1, 0
      - milestones/indexに限定公開星座用のタブを表示するための変数を定義

  - helpers
    - gantt_chart_helper.rb 9, 1
      - limitedsharingmilestoneも利用するにあたり、従来ではmnilestonesのidからmilestonetaskを探索していたが、クラスを確認して分岐するように設定。

  - javascript
    - application.js 9, 0
      - groupbtnhoverremovegrouplinkcardbgメソッドをインクルード
    - bgstarshow.js 4, 4
      - homeの下部に表示されていない問題を修正
    - groupbtnhoverremovegrouplinkcardbg.js 20, 0
      - link_card要素とremove_hover_btn要素を使用し、groupによってくくってgroup-hoverでbgを変更している要素と同じgroupにある要素をgroup-hoverの対象から省きたい際に省くことができる

  - models
    - concerns
      - nanoid_generator.rb 29, 0
        - nanoidを生成するメソッドを定義

    - limited_sharing_milestone.rb 33, 0
      - initialize時にnanoidを生成してセットする
      - hasmanyでlimitedsharingtaskとリレーションしているが、class_nameを用いることで、tasksとして紐づけている
      - その他、必要な設定を定義。milestoneと同様の設定が多い。
    - limited_sharing_task.rb 40, 0
      - initialize時にnanoidを生成してセットする
      - belongs_toでlimitedsharingmilestoneとリレーションしているが、class_nameを用いることでmilestoneとして紐づけている
      - その他、必要なものを定義。taskと同様の設定が多い。
    - milestone.rb 5, 0
      - tasks_completed?を定義
    - user.rb 2, 0
      - limitedsharingmilestoneとlimitedsharingtaskとリレーション

  - views
    - application
      - _title_header.html.erb 1, 1
        - スマホ用に文字サイズを調整

    - gantt_chart
      - _chart_layout.html.erb 5, 1
        - limitedsharingmilestoneの場合はmilestoneのtitle名から詳細モーダルを表示できないように
        - これは、limitedsharingmilestoneの場合、必ず詳細ページにしかチャートが存在しないので、詳細モーダルを表示する必要がないため

    - limited_sharing_milestones
      - _milestone.html.erb 54, 0
        - milestone/indexに表示するための要素
      - _share_confirm_modal.html.erb 33, 0
        - 共有作成時に確認のために表示するモーダル
      - show.html.erb 209, 0
        - 限定公開星座用の詳細ページ
        - ほぼmilestone/showと同様の内容だが、milestone/showがかなりゴチャついていることを考慮して別に作成

    - limited_sharing_tasks
      - show.html.erb 13, 0
        - limitedsharigntask用の詳細モーダル
        - この中から、taskの詳細モーダルcontentを呼び出してパーシャルを共有

    - milestones
      - _milestone.html.erb 27, 13
        - パーシャルに余計なものを渡さないように、completed状態の分岐のロジックをmilestone.completed?に変更。
        - デザインの変更
        - 特に、titleと日付表示部分を切り離すことで、スマホからの表示も少し見やすく
        - その際に、同様のリンクを2つ配置することになったので、groupを用いてどちらにhoverしても両方bgが変化するように
        - また、どうしても完成ボタンがgroup内に入ってしまうのでjsでbgを制御
      - _milestones.html.erb 1, 1
        - ロジックの変更により、complete引数を削除
      - index.html.erb 16, 4
        - 限定公開星座用のタブを追加し、タブの表示名を短縮
      - show.html.erb 121, 54
        - 限定公開ボタンを追加し、公開確認モーダルを配置

    - static_pages
      - home.html.erb 2, 2
        - iconとfooterに背景星が掛かっている問題を修正

    - tasks
      - _progress_button.html.erb 21, 21
        - 全体のサイズなどを決める要素を外に出し、汎用性を上昇
        - 他の人が見る際の進捗表示のサイズをaoutからh-20に変更
      - _task.html.erb 27, 14
        - titleと日付表示部分を切り離すことで、スマホからの表示も少し見やすく
        - その際に、同様のリンクを2つ配置することになったので、groupを用いてどちらにhoverしても両方bgが変化するように
        - また、どうしても完成ボタンがgroup内に入ってしまうのでjsでbgを制御
      - _tasks_show_modal_content.html.erb 3, 1
        - limitedsharingtaskと共有するにあたって、分岐を追加

- config
  - routes.rb 4, 0
    - 限定公開機能へのルーティングを追加
    - 表示のルーティングに関しては見栄えのために指定
- gemfile 2, 0
  - nanoidを追加

## スクリーンショット

<!-- command + shift + control + 4 でスクリーンショットして command + v でここに貼り付けるのが楽。以下のテーブルは必要に応じて使ってください -->
限定公開ボタンと、モーダル
![image](https://github.com/user-attachments/assets/c0a3e49a-cc49-4908-af24-a60b722b3210)
![image](https://github.com/user-attachments/assets/52cb70df-a125-4d61-bfe9-06300c748057)

限定公開星座詳細ページ

![image](https://github.com/user-attachments/assets/a2a79d33-9c3e-4e8f-9aa3-f36b9b307254)

<!-- github copilot レビューは日本語でお願いします -->

