### PR TITLE
fix: 各種タスクの並びをend_date順、start_date順、nilは最後で並び替えました

### DIFF
--- a/app/controllers/milestones_controller.rb
+++ b/app/controllers/milestones_controller.rb
@@ -11,9 +11,9 @@ class MilestonesController < ApplicationController
     @user = current_user
     user_milestones = @user.milestones
     @milestone = Milestone.new
-    @sharing_milestones = @user.limited_sharing_milestones
+    @sharing_milestones = @user.limited_sharing_milestones&.order(created_at: :desc)
     @completed_milestones = user_milestones.where(progress: "completed")&.order(created_at: :desc)
-    @not_completed_milestones = user_milestones.where&.not(progress: "completed")&.order(created_at: :desc)
+    @not_completed_milestones = user_milestones.where&.not(progress: "completed")&.index_order
     @title = "星座一覧"
   end
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -9,9 +9,14 @@ class TasksController < ApplicationController
   def index
     @title = "タスク一覧"
     @user = current_user
-    tasks = @user.tasks.includes(:milestone).order(created_at: :desc)
-    @completed_tasks = tasks.where(progress: :completed).reject(&:milestone_completed?)
-    @not_completed_tasks = tasks.where.not(progress: :completed)
+    base_tasks = @user.tasks.includes(:milestone)
+
+    # 完了したタスク - 作成日の降順
+    completed_tasks_set = base_tasks.where(progress: :completed).index_order
+    @completed_tasks = completed_tasks_set.reject(&:milestone_completed?)
+
+    # 未完了のタスク - 締切日の昇順（nilを最後に表示）、同じ締切日なら開始日の昇順
+    @not_completed_tasks = base_tasks.where.not(progress: :completed).index_order
   end
 
   # GET /tasks/1

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,11 +11,11 @@ class UsersController < ApplicationController
       prepare_meta_tags(@user)
 
       if current_user?(@user)
-        @not_completed_milestones = @user.milestones.where.not(progress: "completed")
-        @completed_milestones = @user.milestones.where(progress: "completed")
+        @not_completed_milestones = not_completed_milestones(public: false)
+        @completed_milestones = completed_milestones(public: false)
       else
-        @not_completed_milestones = @user.milestones.where(is_public: true).where.not(progress: "completed")
-        @completed_milestones = @user.milestones.where(is_public: true).where(progress: "completed")
+        @not_completed_milestones = not_completed_milestones(public: true)
+        @completed_milestones = completed_milestones(public: true)
       end
     end
   end
@@ -28,5 +28,31 @@ class UsersController < ApplicationController
       description: "#{user.name}さんのユーザーページです。",
       url: user_url(user)
     }
+  end
+
+  def not_completed_milestones(public: false)
+    if public
+      @user.milestones
+           .where(is_public: true)
+           .where.not(progress: "completed")
+           .index_order
+    else
+      @user.milestones
+           .where.not(progress: "completed")
+           .index_order
+    end
+  end
+
+  def completed_milestones(public: false)
+    if public
+      @user.milestones
+           .where(is_public: true)
+           .where(progress: "completed")
+           .index_order
+    else
+      @user.milestones
+           .where(progress: "completed")
+           .index_order
+    end
   end
 end

--- a/app/models/milestone.rb
+++ b/app/models/milestone.rb
@@ -35,6 +35,7 @@ class Milestone < ApplicationRecord
   scope :on_chart, -> { where(is_on_chart: true) }
   scope :not_completed, -> { where(progress: [:not_started, :in_progress]) }
   scope :start_date_asc, -> { order(start_date: :asc) }
+  scope :index_order, -> { order(Arel.sql("end_date IS NULL ASC, end_date ASC, start_date ASC")) }
 
   # ######################################
   # メソッド

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -25,6 +25,7 @@ class Task < ApplicationRecord
   scope :not_started, -> { where(progress: :not_started) }
   scope :created_at_desc, -> { order(created_at: :desc) }
   scope :start_date_asc, -> { order(start_date: :asc) }
+  scope :index_order, -> { order(Arel.sql("end_date IS NULL ASC, end_date ASC, start_date ASC")) }
 
   # ######################################
   # メソッド

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,7 +3,7 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   config.hosts << 'hoshi-ni-task-wo.net'
   config.hosts << 'hoshi-ni-task-wo.onrender.com'
-  config.hosts << 'hoshi-ni-task-wo-pr-178.onrender.com'
+  config.hosts << 'hoshi-ni-task-wo-pr-179.onrender.com'
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.


### PR DESCRIPTION
タスクが無秩序に並んでいて見づらかったので、並び替えました。
end_date順に並び替え、その中でstart_date順に並び替え、nilは最後に並ぶように変更しました。

また、それをtaskとmilestoneのモデルにscopeとして、index_orderとして追加しました。