### PR TITLE
オートコンプリート機能を実装しました closes #57

### DIFF
--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,6 +1,8 @@
 import { Application } from "@hotwired/stimulus"
+import { Autocomplete } from "stimulus-autocomplete"
 
 const application = Application.start()
+application.register("autocomplete", Autocomplete)
 
 // Configure Stimulus development experience
 application.debug = false

--- a/app/models/milestone.rb
+++ b/app/models/milestone.rb
@@ -41,6 +41,10 @@ class Milestone < ApplicationRecord
   # メソッド
   # ######################################
 
+  def completed?
+    progress == "completed"
+  end
+
   def tasks_completed?
     tasks.all? { |task| task.progress == "completed" }
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -22,6 +22,7 @@ class Task < ApplicationRecord
   scope :valid_dates, -> { where.not(start_date: nil, end_date: nil) }
   scope :completed, -> { where(progress: :completed) }
   scope :in_progress, -> { where(progress: :in_progress) }
+  scope :not_completed, -> { where.not(progress: :completed) }
   scope :not_started, -> { where(progress: :not_started) }
   scope :created_at_desc, -> { order(created_at: :desc) }
   scope :start_date_asc, -> { order(start_date: :asc) }

--- a/app/views/application/_search_or_sort_select.html.erb
+++ b/app/views/application/_search_or_sort_select.html.erb
@@ -1,22 +1,43 @@
-<%# q:とpath:は必須、frame_target:はオプション %>
-<%# frame_targetが渡されている場合は、そのframe_target + "_tasks_content_frame"を使用 %>
+<%# q:とpath:は必須、_frame_target:,_progress:, _milestone_id:は任意 %>
+<%# frame_targetが渡されている場合は、そのframe_target + "_search_sort_content_frame"を使用する %>
+
+<%# stimulus_autocompleteで使用するパスをここで決定する %>
+<%# @q.klassがTaskの場合はautocomplete_tasks_pathを、Milestoneの場合はautocomplete_milestones_pathを使用する %>
+<%# _milestone_idが渡されている場合は、autocomplete_pathにそのIDを渡す %>
+<% 
+  if (defined? _milestone_id)
+    autocomplete_path = ((@q.klass == Task) ? autocomplete_tasks_path(milestone_id: _milestone_id) : autocomplete_milestones_path(milestone_id: _milestone_id))
+  elsif (defined? _progress)
+    autocomplete_path = ((@q.klass == Task) ? autocomplete_tasks_path(progress: _progress) : autocomplete_milestones_path(progress: _progress))
+  else
+    autocomplete_path = ((@q.klass == Task) ? autocomplete_tasks_path : autocomplete_milestones_path)
+  end
+%>
+
 <div class="flex justify-center h-10 items-center mt-2 mb-5">
-  <%= search_form_for @q, url: path, class: "w-[60%]", html: { data: { turbo_frame: "#{(defined? _frame_target) ? "#{_frame_target}_search_sort_content_frame" : "search_sort_content_frame"}", controller: "form", action: "input->form#submit" } } do |f| %>
-    <label class="input input-sm md:input-md bg-base-300/40 shadow">
-      <svg class="h-[1em] opacity-50" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-        <g
-        stroke-linejoin="round"
-        stroke-linecap="round"
-        stroke-width="2.5"
-        fill="none"
-        stroke="currentColor"
-        >
-        <circle cx="11" cy="11" r="8"></circle>
-        <path d="m21 21-4.3-4.3"></path>
-        </g>
-      </svg>
-      <input class="grow" placeholder="タイトル or 詳細" type="search" name="q[title_or_description_cont]" id="q_title_or_description_cont">
-    </label>
+  <%= search_form_for @q, url: path, class: "w-[60%]", html: { data: { turbo_frame: "#{(defined? _frame_target) ? "#{_frame_target}_search_sort_content_frame" : "search_sort_content_frame"}", controller: "form", action: "input->form#submit change->form#submit" } } do |f| %>
+
+    <%# stimulus_autocompleteによるautocomplete %>
+    <div data-controller="autocomplete" data-autocomplete-url-value="<%= autocomplete_path %>" role="combobox">
+      <label class="input input-sm md:input-md bg-base-300/40 shadow">
+        <svg class="h-[1em] opacity-50" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+          <g
+          stroke-linejoin="round"
+          stroke-linecap="round"
+          stroke-width="2.5"
+          fill="none"
+          stroke="currentColor"
+          >
+          <circle cx="11" cy="11" r="8"></circle>
+          <path d="m21 21-4.3-4.3"></path>
+          </g>
+        </svg>
+        <input class="grow" placeholder="タイトル or 詳細" type="search" name="q[title_or_description_cont]" id="q_title_or_description_cont" data-autocomplete-target="input">
+      </label>
+
+      <%= f.hidden_field :title, data: { autocomplete_target: 'hidden' } %>
+      <ul class="list-group absolute w-[400px]" data-autocomplete-target="results"></ul>
+    </div>
   <% end %>
 
   <div class="divider divider-horizontal text-xs">OR</div>

--- a/app/views/application/_search_or_sort_select.html.erb
+++ b/app/views/application/_search_or_sort_select.html.erb
@@ -36,7 +36,7 @@
       </label>
 
       <%= f.hidden_field :title, data: { autocomplete_target: 'hidden' } %>
-      <ul class="list-group absolute w-[400px]" data-autocomplete-target="results"></ul>
+      <ul class="list-group absolute w-80 md:w-100" data-autocomplete-target="results"></ul>
     </div>
   <% end %>
 

--- a/app/views/milestones/_milestones.html.erb
+++ b/app/views/milestones/_milestones.html.erb
@@ -1,7 +1,20 @@
-
 <!-- 星座 -->
-<div id="milestones_content" class="mx-auto">
-  <% milestones.each do |milestone| %>
-    <%= render "milestones/milestone", milestone: milestone %>
-  <% end %>
-</div>
+<% if milestones.any? %>
+  <div id="milestones_content" class="mx-auto">
+    <% milestones.each do |milestone| %>
+      <%= render "milestones/milestone", milestone: milestone %>
+    <% end %>
+  </div>
+<% else %>
+  <div id="milestones_content" class="mx-auto">
+    <div class="card mb-4 w-full h-30 p-4 bg-base-300/40 shadow-xl/10">
+      <div class="flex size-full items-center justify-center">
+        <div class="flex items-center">
+          <%= render "stars_icon" %>
+        </div>
+
+        <p class="text-lg ml-2">星座が見つかりません</p>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/milestones/autocomplete.html.erb
+++ b/app/views/milestones/autocomplete.html.erb
@@ -1,0 +1,6 @@
+<% @milestones.each do |milestone| %>
+  <li class="relative z-30 flex w-full items-center text-sm py-2 px-3 bg-base-300 hover:bg-base-100" role="option" data-autocomplete-value="<%= milestone.id %>" data-autocomplete-label="<%= milestone.title %>">
+    <%= milestone.title %>
+  </li>
+<% end %>
+

--- a/app/views/milestones/index.html.erb
+++ b/app/views/milestones/index.html.erb
@@ -77,16 +77,29 @@
         <div class="tab-content border-base-300 bg-base-100 p-3">
 
           <!-- 星座 -->
+          <% if @sharing_milestones.any? %>
             <% @sharing_milestones.each do |milestone| %>
               <%= render "limited_sharing_milestones/milestone", milestone: milestone %>
             <% end %>
+          <% else %>
+            <div class="mx-auto">
+              <div class="card mb-4 w-full h-30 p-4 bg-base-300/40 shadow-xl/10">
+                <div class="flex size-full items-center justify-center">
+                  <div class="flex items-center">
+                    <%= render "stars_icon" %>
+                  </div>
+
+                  <p class="text-lg ml-2">星座が見つかりません</p>
+                </div>
+              </div>
+            </div>
+          <% end %>
 
         </div>
 
       </div>
     </div>
   </div>
-
 
   <div class="mt-10" >
     <%= render "menu_bar" %>

--- a/app/views/milestones/index.html.erb
+++ b/app/views/milestones/index.html.erb
@@ -25,7 +25,7 @@
 
           <!-- 検索欄、ソートの切り替えセレクト -->
           <div class="mb-3">
-            <%= render "search_or_sort_select", q: @q, path: milestones_path %>
+            <%= render "search_or_sort_select", q: @q, path: milestones_path, _progress: "not_completed" %>
           </div>
 
           <% if current_user.guest? %>
@@ -63,7 +63,7 @@
         <div class="tab-content border-base-300 bg-base-100 p-3">
           <!-- ソートの切り替えセレクト -->
           <div class="mb-3">
-            <%= render "search_or_sort_select", q: @q, path: milestones_path, _frame_target: "secondary" %>
+            <%= render "search_or_sort_select", q: @q, path: milestones_path, _frame_target: "secondary", _progress: "completed" %>
           </div>
 
           <!-- 星座 -->

--- a/app/views/milestones/show.html.erb
+++ b/app/views/milestones/show.html.erb
@@ -300,7 +300,7 @@
 
           <!-- ソートの切り替えセレクト -->
           <div class="mb-3">
-            <%= render "search_or_sort_select", q: @q, path: milestone_path(@milestone) %>
+            <%= render "search_or_sort_select", q: @q, path: milestone_path(@milestone), _milestone_id: @milestone.id %>
           </div>
 
           <% if !@is_milestone_completed && current_user?(@milestone.user) %>

--- a/app/views/tasks/_tasks.html.erb
+++ b/app/views/tasks/_tasks.html.erb
@@ -1,7 +1,20 @@
 <!-- 星座 -->
-<div id="tasks_content" class="mx-auto">
-  <% tasks.each do |task| %>
-    <%= render "tasks/task", task: task %>
-  <% end %>
-</div>
+<% if tasks.any? %>
+  <div id="tasks_content" class="mx-auto">
+    <% tasks.each do |task| %>
+      <%= render "tasks/task", task: task %>
+    <% end %>
+  </div>
+<% else %>
+  <div id="tasks_content" class="mx-auto">
+    <div class="card mb-4 w-full h-30 p-4 bg-base-300/40 shadow-xl/10">
+      <div class="flex size-full items-center justify-center">
+        <div class="flex items-center">
+          <%= render "star_icon" %>
+        </div>
 
+        <p class="text-lg ml-2">タスクが見つかりません</p>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/tasks/autocomplete.html.erb
+++ b/app/views/tasks/autocomplete.html.erb
@@ -1,0 +1,7 @@
+  <% @tasks.each do |task| %>
+    <% if task.milestone.nil? || !task.milestone.completed? %>
+      <li class="relative z-30 flex w-full items-center text-sm py-2 px-3 bg-base-300 hover:bg-base-100" role="option" data-autocomplete-value="<%= task.id %>" data-autocomplete-label="<%= task.title %>">
+        <%= task.title %>
+      </li>
+    <% end %>
+  <% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -24,7 +24,7 @@
 
           <!-- ソートの切り替えセレクト -->
           <div class="mb-3">
-            <%= render "search_or_sort_select", q: @q, path: tasks_path %>
+            <%= render "search_or_sort_select", q: @q, path: tasks_path ,_progress: "not_completed" %>
           </div>
 
           <!-- タスクの追加ボタン -->
@@ -44,7 +44,7 @@
 
           <!-- ソートの切り替えセレクト -->
           <div class="mb-3">
-            <%= render "search_or_sort_select", q: @q, path: tasks_path, _frame_target: "secondary" %>
+            <%= render "search_or_sort_select", q: @q, path: tasks_path, _frame_target: "secondary", _progress: "completed" %>
           </div>
 
           <!-- タスク -->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,10 @@ Rails.application.routes.draw do
   resources :tasks do
     patch "update_progress", on: :member
     get "share" => "limited_sharing_tasks#show", on: :member
+
+    collection do
+      get :autocomplete
+    end
   end
   namespace :tasks do
     resources :copies, only: [:show, :create]
@@ -13,6 +17,10 @@ Rails.application.routes.draw do
     get "show_complete_page", on: :member
     patch "complete", on: :member
     get "share" => "limited_sharing_milestones#show", on: :member
+
+    collection do
+      get :autocomplete
+    end
   end
   namespace :milestones do
     resources :copies, only: [:show, :create]

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.13",
     "@tailwindcss/cli": "^4.1.3",
+    "stimulus-autocomplete": "^3.1.0",
     "tailwindcss": "^4.1.3",
     "tailwindcss-intersect": "^2.2.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -525,6 +525,11 @@ picomatch@^2.3.1:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+stimulus-autocomplete@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/stimulus-autocomplete/-/stimulus-autocomplete-3.1.0.tgz#7c9292706556ed0a87abf60ea2688bf0ea1176a8"
+  integrity sha512-SmVViCdA8yCl99oV2kzllNOqYjx7wruY+1OjAVsDTkZMNFZG5j+SqDKHMYbu+dRFy/SWq/PParzwZHvLAgH+YA==
+
 tailwindcss-intersect@^2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/tailwindcss-intersect/-/tailwindcss-intersect-2.2.0.tgz"


### PR DESCRIPTION
<!-- github copilot レビューは日本語でお願いします -->
# 概要

<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->

オートコンプリート機能を実装しました。
検索窓に入力すると、そのタブ上に表示されているモノのtitleを表示します。

# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイントです -->

- app
  - controllers
    - milestones_controller.rb (M) 32, 0
      - autocompleteメソッドを実装。
      - progressが渡されているかどうかで分岐して絞り込む
    - tasks_controller.rb (M) 45, 0
      - autocompleteメソッドを実装。
      - progressが渡されているかどうかで分岐して絞り込む
      - milestone_idが渡されている場合、そのmilestoneの所有者あるいはpublicであればそのtasksで絞りこむ
  - javascript/controllers
    - application.js (M) 2, 0
      - stimulus_autocompleteの記述を追加
  - models
    - milestone.rb (M) 4, 0
      - completed?メソッドを追加
    - task.rb (M) 1, 0
      - not_completedスコープを追加
  - views
    - application
      - _search_or_sort_select.html.erb (M) 39, 18
        - stimulus_autocompleteの記述を追加
        - _progressか_milestone_idを受け取っている場合、tasks#autocomplete, milestones#completeに受け渡す
    - milestones
      - _milestones.html.erb (M) 19, 6
        - milestonesが存在しない場合の表示を追加
      - autocomplete.html.erb (A) 6, 0
        - autocompleteで一覧に表示されるビューファイル
      - index.html.erb (M) 16, 3
        - _progressを追加
        - shaling_milestoneが無い場合の記述を追加
      - show.html.erb (M) 1, 1
        - _milestone_idを追加
    - tasks
      - _tasks.html.erb (M) 18, 5
        - tasksが存在しない場合の表示を追加
      - autocomplete.html.erb (A) 7, 0
        - autocompleteで一覧に表示されるビューファイル
      - index.html.erb (M) 2, 2
        - _progressを追加
  - config
    - routes.rb (M) 8, 0
      - #autocompleteへのルーティングを追加
  - package.json (M) 1, 0
    - stimulus_autocompleteを追加


## スクリーンショット
![image](https://github.com/user-attachments/assets/3df90d30-0ae9-4bcd-8cb2-dcc152990343)

<!-- github copilot レビューは日本語でお願いします -->

