### PR TITLE
milestoneのバリデーションの漏れを修正し、ロジックを少し改善しました

### DIFF
--- a/app/controllers/limited_sharing_milestones_controller.rb
+++ b/app/controllers/limited_sharing_milestones_controller.rb
@@ -6,8 +6,6 @@ class LimitedSharingMilestonesController < ApplicationController
 
   def show
     @title = "限定公開の星座"
-    @is_milestone_completed = (@milestone.progress == "completed")
-    @is_not_milestone_on_chart = @milestone.is_on_chart == false
 
     prepare_meta_tags(@milestone)
     prepare_for_chart(@milestone) if @milestone.is_on_chart

--- a/app/controllers/milestones_controller.rb
+++ b/app/controllers/milestones_controller.rb
@@ -14,8 +14,17 @@ class MilestonesController < ApplicationController
 
     @sharing_milestones = @user.limited_sharing_milestones&.order(created_at: :desc)
 
-    @completed_milestones = user_milestones.where(progress: "completed")
-    @not_completed_milestones = user_milestones.where&.not(progress: "completed")
+    # 二度クエリを発行するのではなく、rubyで処理したほうが早い？
+    @completed_milestones = []
+    @not_completed_milestones = []
+    user_milestones.each do |milestone|
+      if milestone.completed?
+        @completed_milestones << milestone
+      else
+        @not_completed_milestones << milestone
+      end
+    end
+
     @title = "星座一覧"
   end
 
@@ -32,9 +41,6 @@ class MilestonesController < ApplicationController
              else
                "#{@milestone.user.name}さんの星座詳細"
              end
-
-    @is_milestone_completed = (@milestone.progress == "completed")
-    @is_not_milestone_on_chart = (@milestone.is_on_chart == false)
 
     if @milestone.is_public || current_user?(@milestone.user)
       prepare_meta_tags(@milestone)
@@ -62,7 +68,6 @@ class MilestonesController < ApplicationController
   # GET /milestones/1/edit
   def edit; end
 
-  # POST /milestones
   def create
     if current_user.guest?
       flash[:alert] = "ゲストユーザーは星座を作成できません"
@@ -76,10 +81,20 @@ class MilestonesController < ApplicationController
       flash[:notice] = "星座を作成しました"
       redirect_to milestones_path
     else
+      # renderで/indexを表示するため、indexアクションと同様の処理
       @user = current_user
       user_milestones = milestones_ransack_result
-      @completed_milestones = user_milestones.where(progress: "completed")
-      @not_completed_milestones = user_milestones.where&.not(progress: "completed")
+
+      @completed_milestones = []
+      @not_completed_milestones = []
+      user_milestones.each do |milestone|
+        if milestone.completed?
+          @completed_milestones << milestone
+        else
+          @not_completed_milestones << milestone
+        end
+      end
+
       @sharing_milestones = @user.limited_sharing_milestones&.order(created_at: :desc)
       @title = "星座一覧"
       @milestones_new_modal_open = true
@@ -94,6 +109,7 @@ class MilestonesController < ApplicationController
     if @milestone.update(milestone_params)
       redirect_to @milestone, notice: "星座を更新しました"
     else
+      # renderで/showを表示するため、showアクションと同様の処理
       prepare_for_chart(@milestone)
       @title = "星座詳細"
       @milestones_edit_modal_open = true
@@ -214,6 +230,9 @@ class MilestonesController < ApplicationController
   end
 
   def prepare_for_chart(milestone)
+    return if milestone.start_date.nil? || milestone.end_date.nil?
+    return unless milestone.on_chart?
+
     # milestone_chartの幅と位置情報を計算
     @milestone_widths, @milestone_lefts = milestone_widths_lefts_hash([milestone])
     @date_range = date_range([milestone])

--- a/app/controllers/milestones_controller.rb
+++ b/app/controllers/milestones_controller.rb
@@ -14,17 +14,8 @@ class MilestonesController < ApplicationController
 
     @sharing_milestones = @user.limited_sharing_milestones&.order(created_at: :desc)
 
-    # 二度クエリを発行するのではなく、rubyで処理したほうが早い？
-    @completed_milestones = []
-    @not_completed_milestones = []
-    user_milestones.each do |milestone|
-      if milestone.completed?
-        @completed_milestones << milestone
-      else
-        @not_completed_milestones << milestone
-      end
-    end
-
+    # partitionメソッドを使用して、completed?がtrueのものとfalseのものに分ける
+    @completed_milestones, @not_completed_milestones = user_milestones.partition(&:completed?)
     @title = "星座一覧"
   end
 
@@ -85,16 +76,7 @@ class MilestonesController < ApplicationController
       @user = current_user
       user_milestones = milestones_ransack_result
 
-      @completed_milestones = []
-      @not_completed_milestones = []
-      user_milestones.each do |milestone|
-        if milestone.completed?
-          @completed_milestones << milestone
-        else
-          @not_completed_milestones << milestone
-        end
-      end
-
+      @completed_milestones, @not_completed_milestones = user_milestones.partition(&:completed?)
       @sharing_milestones = @user.limited_sharing_milestones&.order(created_at: :desc)
       @title = "星座一覧"
       @milestones_new_modal_open = true

--- a/app/models/limited_sharing_milestone.rb
+++ b/app/models/limited_sharing_milestone.rb
@@ -34,4 +34,8 @@ class LimitedSharingMilestone < ApplicationRecord
   def open?
     true
   end
+
+  def on_chart?
+    is_on_chart == true
+  end
 end

--- a/app/models/milestone.rb
+++ b/app/models/milestone.rb
@@ -11,7 +11,8 @@ class Milestone < ApplicationRecord
   # 日付関連のバリデーション
   validate :start_date_check # 開始日が終了日より前の日付を設定する
   validate :end_date_check # 終了日が開始日より後の日付を設定する
-  validate :tasks_date_check, if: -> { start_date.present? && end_date.present? && is_on_chart } # タスクの日付がマイルストーンの日付内に収まるかチェック
+  # タスクの日付がマイルストーンの日付内に収まるかチェック
+  validate :tasks_date_check, if: -> { start_date.present? && end_date.present? && is_on_chart }
   validate :tasks_require_date, if: -> { is_on_chart }
   validate :on_chart_date_check, if: -> { is_on_chart }
 
@@ -142,7 +143,7 @@ class Milestone < ApplicationRecord
 
     tasks.each do |task|
       if task.start_date.blank? && task.end_date.blank?
-        errors.add(:base, "チャートに表示する場合、各タスクは開始日か終了日の少なくとも一方を設定してください")
+        errors.add(:base, "チャートに表示する場合、タスク「title: #{task.title}」は開始日か終了日の少なくとも一方を設定してください")
         break
       end
     end

--- a/app/models/milestone.rb
+++ b/app/models/milestone.rb
@@ -7,13 +7,13 @@ class Milestone < ApplicationRecord
   validates :title, presence: true
   validates :description, length: { maximum: 150 }, allow_blank: true
 
-  validates :start_date, presence: true, if: -> { is_on_chart }
-  validate :start_date_check
-
-  validates :end_date, presence: true, if: -> { is_on_chart }
-  validate :end_date_check
-
-  validate :tasks_date_check, if: -> { is_on_chart }
+  # is_on_chartがtrueの場合、start_dateとend_dateは必須
+  # 日付関連のバリデーション
+  validate :start_date_check # 開始日が終了日より前の日付を設定する
+  validate :end_date_check # 終了日が開始日より後の日付を設定する
+  validate :tasks_date_check, if: -> { start_date.present? && end_date.present? && is_on_chart } # タスクの日付がマイルストーンの日付内に収まるかチェック
+  validate :tasks_require_date, if: -> { is_on_chart }
+  validate :on_chart_date_check, if: -> { is_on_chart }
 
   validates :progress, presence: true
   validates :color, presence: true
@@ -22,6 +22,7 @@ class Milestone < ApplicationRecord
 
   validates :is_public, inclusion: { in: [true, false] }
   validates :is_on_chart, inclusion: { in: [true, false] }
+  validates :is_open, inclusion: { in: [true, false] }
 
   # Enum for progress status
   # :not_started = 0
@@ -79,6 +80,10 @@ class Milestone < ApplicationRecord
     is_open == true
   end
 
+  def on_chart?
+    is_on_chart == true
+  end
+
   def copy(set_date)
     copy = dup
     copy.title = "#{title}_copy"
@@ -125,20 +130,40 @@ class Milestone < ApplicationRecord
     errors.add(:end_date, "は開始日より後の日付を設定してください") if end_after_start
   end
 
+  def on_chart_date_check
+    return unless is_on_chart
+
+    errors.add(:start_date, "チャートに表示する場合、開始日と終了日を設定してください") if start_date.blank? || end_date.blank?
+  end
+
+  # is_on_chartがtrueの場合、各タスクはstart_dateかend_dateの少なくとも一方を持つ必要がある
+  def tasks_require_date
+    return unless tasks.any?
+
+    tasks.each do |task|
+      if task.start_date.blank? && task.end_date.blank?
+        errors.add(:base, "チャートに表示する場合、各タスクは開始日か終了日の少なくとも一方を設定してください")
+        break
+      end
+    end
+  end
+
+  # タスクの日付がマイルストーンの日付内に収まるかチェック
   def tasks_date_check
     return unless tasks.any?
 
     tasks.each do |task|
       validate_task_start_date(task) unless task.start_date.blank?
-
       validate_task_end_date(task) unless task.end_date.blank?
     end
   end
 
+  # tasks_date_checkメソッドで使用するバリデーションメソッド
   def validate_task_start_date(task)
     errors.add(:start_date, "は紐づくタスクの開始日以前に設定してください。タスクは星座の期間内に収まる必要があります") if task.start_date < start_date
   end
 
+  # tasks_date_checkメソッドで使用するバリデーションメソッド
   def validate_task_end_date(task)
     errors.add(:end_date, "は紐づくタスクの終了日以降に設定してください。タスクは星座の期間内に収まる必要があります") if task.end_date > end_date
   end

--- a/app/views/limited_sharing_milestones/show.html.erb
+++ b/app/views/limited_sharing_milestones/show.html.erb
@@ -1,4 +1,5 @@
 <div class="h-full w-full">
+  <% milestone_completed = @milestone.completed? %>
   <!-- 月の画像 -->
   <%= render 'title_header', title: @title %>
 
@@ -10,7 +11,7 @@
 
     <!-- 完成状態は星座アイコンと完成コメント -->
     <!-- 星座のアイコン -->
-    <% if @is_milestone_completed %>
+    <% if milestone_completed %>
       <!-- title -->
       <div class="text-3xl">
         <%= "#{@milestone.title} 座" %>
@@ -100,7 +101,7 @@
     <div class="mb-8 flex h-full md:h-[100px] items-center justify-center">
       <div class="flex items-center justify-center rounded-xl text-base-200 md:w-3/4 md:mb-0">
         <div>
-          <%if @is_milestone_completed %>
+          <% if milestone_completed %>
             <div class="flex items-center">
               <div class="mr-2 text-center">
                 チャートに表示する：
@@ -146,7 +147,7 @@
           <%= render "tasks/tasks", tasks: @milestone_tasks %>
 
         </div>
-        <% if @is_not_milestone_on_chart || @is_milestone_completed %>
+        <% if !@milestone.on_chart? || milestone_completed %>
           <!-- 完成状態の場合チャートは表示しない -->
         <% else %>
           <!-- チャート -->

--- a/app/views/milestones/show.html.erb
+++ b/app/views/milestones/show.html.erb
@@ -1,4 +1,5 @@
-<div class="h-full w-full">
+  <% milestone_completed = @milestone.completed? %>
+  <% milestone_on_chart = @milestone.on_chart? %>
   <!-- 月の画像 -->
   <%= render 'title_header', title: @title %>
 
@@ -10,7 +11,7 @@
 
     <!-- 完成状態は星座アイコンと完成コメント -->
     <!-- 星座のアイコン -->
-    <% if @is_milestone_completed %>
+    <% if milestone_completed %>
       <!-- title -->
       <div class="text-3xl">
         <%= "#{@milestone.title} 座" %>
@@ -112,7 +113,7 @@
               <% end %>
             </div>
 
-            <%if @is_milestone_completed %>
+            <% if milestone_completed %>
               <div class="flex items-center">
                 <div class="mr-2 text-center">
                   チャートに表示する：
@@ -126,7 +127,7 @@
                 <div class="mr-2 text-center">
                   チャートに表示する：
                 </div>
-                <% if @milestone.is_on_chart %>
+                <% if milestone_on_chart %>
                   <span class="badge badge-md badge-primary md:badge-lg">ON</span>
                 <% else %>
                   <span class="badge badge-md badge-base-300 md:badge-lg">OFF</span>
@@ -303,7 +304,7 @@
             <%= render "search_or_sort_select", q: @q, path: milestone_path(@milestone), _milestone_id: @milestone.id %>
           </div>
 
-          <% if !@is_milestone_completed && current_user?(@milestone.user) %>
+          <% if !milestone_completed && current_user?(@milestone.user) %>
             <!-- 新規作成ボタン -->
             <%= render "tasks/add_task_button", milestone: @milestone %>
           <% end %>
@@ -314,8 +315,8 @@
           <% end %>
 
         </div>
-        <% if @is_not_milestone_on_chart || @is_milestone_completed %>
-          <!-- 完成状態の場合チャートは表示しない -->
+        <% if !milestone_on_chart || milestone_completed || @milestone.start_date.blank? || @milestone.end_date.blank? %>
+          <!-- 完成状態、または開始日か終了日が無い場合はチャートは表示しない -->
         <% else %>
           <!-- チャート -->
           <input type="radio" name="my_tabs" class="tab" aria-label="チャート"  />
@@ -376,5 +377,4 @@
     });
   });
 </script>
-
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,6 +3,7 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   config.hosts << 'hoshi-ni-task-wo.net'
   config.hosts << 'hoshi-ni-task-wo.onrender.com'
+  config.hosts << 'hoshi-ni-task-wo-pr-199.onrender.com'
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.


### PR DESCRIPTION
<!-- github copilot レビューは日本語でお願いします -->
# 概要

<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->

milestoneのバリデーションに漏れがあり、特定の条件でエラーが起こっていた問題を修正しました。
また、controllerとビューのロジックを少し改善しました。


# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイントです -->

- app
  - controllers
    - limited_sharing_milestones_controller.rb (変更: 0行追加, 2行削除)
      - リーディングのしやすさのため、@is_milestone_completed, @is_not_milestone_on_chartを使用しないロジックに変更
    - milestones_controller.rb (変更: 27行追加, 8行削除)
      - リーディングのしやすさのため、@is_milestone_completed, @is_not_milestone_on_chartを使用しないロジックに変更
      - 二度発行していたクエリを、rubyのeachを用いて書き換え
      - prepare_for_chartをmilestoneに日付がいづれか存在しないか、on_chart出ないばあい実行しないように変更
  - models
    - limited_sharing_milestone.rb (変更: 4行追加, 0行削除)
      - on_chart?メソッドを追加
    - milestone.rb (変更: 33行追加, 8行削除)
      - is_openというスコープと、on_chart?メソッドを追加
      - on_chartの場合に、日付の両方が存在するよう確認するバリデーションを追加
      - on_chartの場合に、タスクに日付のいずれかが存在するよう確認するバリデーションを追加
  - views
    - limited_sharing_milestones
      - show.html.erb (変更: 4行追加, 3行削除)
        - リーディングのしやすさのため、@is_milestone_completed, @is_not_milestone_on_chartを使用しないロジックに変更
    - milestones
      - show.html.erb (変更: 8行追加, 8行削除)
        - リーディングのしやすさのため、@is_milestone_completed, @is_not_milestone_on_chartを使用しないロジックに変更


<!-- github copilot レビューは日本語でお願いします -->

