### PR TITLE
本日の日付の色が土日の色に打ち消される問題を修正、各種ローディング追加

### DIFF
--- a/app/helpers/gantt_chart_helper.rb
+++ b/app/helpers/gantt_chart_helper.rb
@@ -77,4 +77,14 @@ module GanttChartHelper
   def milestone_title_truncate_num(milestone)
     [milestone.tasks.count * 2, 10].max
   end
+
+  def today_color(date)
+    if date == Time.zone.today
+      "bg-accent"
+    elsif date.wday.zero? || date.wday == 6
+      "bg-error"
+    else
+      ""
+    end
+  end
 end

--- a/app/helpers/gantt_chart_helper.rb
+++ b/app/helpers/gantt_chart_helper.rb
@@ -78,11 +78,33 @@ module GanttChartHelper
     [milestone.tasks.count * 2, 10].max
   end
 
-  def today_color(date, transparent = nil)
+  def date_class(date)
     if date == Time.zone.today
-      "bg-accent#{transparent || ''}"
+      "today"
     elsif date.wday.zero? || date.wday == 6
-      "bg-error#{transparent || ''}"
+      "weekend"
+    else
+      "weekday"
+    end
+  end
+
+  def date_line_color(date)
+    case date_class(date)
+    when "today"
+      "bg-accent/20"
+    when "weekend"
+      "bg-error/20"
+    else
+      ""
+    end
+  end
+
+  def date_header_color(date)
+    case date_class(date)
+    when "today"
+      "bg-accent/70"
+    when "weekend"
+      "bg-error/70"
     else
       ""
     end

--- a/app/helpers/gantt_chart_helper.rb
+++ b/app/helpers/gantt_chart_helper.rb
@@ -78,11 +78,11 @@ module GanttChartHelper
     [milestone.tasks.count * 2, 10].max
   end
 
-  def today_color(date)
+  def today_color(date, transparent = nil)
     if date == Time.zone.today
-      "bg-accent"
+      "bg-accent#{transparent || ''}"
     elsif date.wday.zero? || date.wday == 6
-      "bg-error"
+      "bg-error#{transparent || ''}"
     else
       ""
     end

--- a/app/javascript/controllers/loading_controller.js
+++ b/app/javascript/controllers/loading_controller.js
@@ -10,4 +10,13 @@ export default class extends Controller {
       this.loading_animationTarget.showModal();
     }, 150);
   }
+
+  disconnect() {
+    console.log("disconnect");
+    if (this.timeout) {
+      clearTimeout(this.timeout);
+    }
+    // ローディングアニメーションを閉じる
+    this.loading_animationTarget.close();
+  }
 }

--- a/app/views/gantt_chart/_chart.html.erb
+++ b/app/views/gantt_chart/_chart.html.erb
@@ -49,7 +49,7 @@
                 <% end %>
               </div>
             <% else %>
-              <%= button_to milestone_open_toggle_path(milestone), class: "hover:cursor-pointer hover:bg-base-100/30 w-full mt-2", method: :patch do %>
+              <%= button_to milestone_open_toggle_path(milestone), class: "hover:cursor-pointer hover:bg-base-100/30 w-full mt-2", method: :patch, data: { action: "click->loading#show" } do %>
                 <span class="material-symbols-outlined">
                   left_panel_open
                 </span>

--- a/app/views/gantt_chart/_chart_layout.html.erb
+++ b/app/views/gantt_chart/_chart_layout.html.erb
@@ -10,7 +10,7 @@
         </div>
         <div class="flex flex-col z-60">
           <% date_range.each_with_index do |date, index| %>
-            <div id="<%= (date == Time.zone.today) ? 'today' : '' %>" class="h-[40px] flex items-center justify-center text-sm border-b border-base-100 <%= today_color(date) + "/70" %> <%= (date.mday == 1) ? 'border-t-3 border-t-info' : '' %>">
+            <div id="<%= (date == Time.zone.today) ? 'today' : '' %>" class="h-[40px] flex items-center justify-center text-sm border-b border-base-100 <%= today_color(date, "/70") %> <%= (date.mday == 1) ? 'border-t-3 border-t-info' : '' %>">
               <%= date.strftime("%m/%d") %>
             </div>
           <% end %>
@@ -78,7 +78,7 @@
               class="h-[40px] border-b border-base-100 z-30
               <%= (index == 0) ? 'border-t' : '' %>
               <%= (date.mday == 1) ? 'border-t-3 border-t-info' : '' %>
-              <%= today_color(date)+ "/20" %>
+              <%= today_color(date, "/20") %>
               "
               style="width: max(<%= chart_total_width %>px, 100%);"
             >

--- a/app/views/gantt_chart/_chart_layout.html.erb
+++ b/app/views/gantt_chart/_chart_layout.html.erb
@@ -10,7 +10,7 @@
         </div>
         <div class="flex flex-col z-60">
           <% date_range.each_with_index do |date, index| %>
-            <div id="<%= (date == Time.zone.today) ? 'today' : '' %>" class="h-[40px] flex items-center justify-center text-sm border-b border-base-100 <%= (date.wday == 0) || (date.wday == 6) ? 'bg-error/70' : '' %> <%= (date == Time.zone.today) ? 'bg-accent/70' : '' %> <%= (date.mday == 1) ? 'border-t-3 border-t-info' : '' %>">
+            <div id="<%= (date == Time.zone.today) ? 'today' : '' %>" class="h-[40px] flex items-center justify-center text-sm border-b border-base-100 <%= today_color(date) + "/70" %> <%= (date.mday == 1) ? 'border-t-3 border-t-info' : '' %>">
               <%= date.strftime("%m/%d") %>
             </div>
           <% end %>
@@ -78,8 +78,7 @@
               class="h-[40px] border-b border-base-100 z-30
               <%= (index == 0) ? 'border-t' : '' %>
               <%= (date.mday == 1) ? 'border-t-3 border-t-info' : '' %>
-              <%= (date.wday == 0) || (date.wday == 6) ? 'bg-error/20' : '' %>
-              <%= (date == Time.zone.today) ? 'bg-accent/20' : '' %>
+              <%= today_color(date)+ "/20" %>
               "
               style="width: max(<%= chart_total_width %>px, 100%);"
             >

--- a/app/views/gantt_chart/_chart_layout.html.erb
+++ b/app/views/gantt_chart/_chart_layout.html.erb
@@ -10,7 +10,11 @@
         </div>
         <div class="flex flex-col z-60">
           <% date_range.each_with_index do |date, index| %>
-            <div id="<%= (date == Time.zone.today) ? 'today' : '' %>" class="h-[40px] flex items-center justify-center text-sm border-b border-base-100 <%= today_color(date, "/70") %> <%= (date.mday == 1) ? 'border-t-3 border-t-info' : '' %>">
+
+            <%# 日付表示部の色を決める %>
+            <% date_color = date_header_color(date) %>
+
+            <div id="<%= (date == Time.zone.today) ? 'today' : '' %>" class="h-[40px] flex items-center justify-center text-sm border-b border-base-100 <%= date_color %> <%= (date.mday == 1) ? 'border-t-3 border-t-info' : '' %>">
               <%= date.strftime("%m/%d") %>
             </div>
           <% end %>
@@ -74,11 +78,14 @@
           <!-- 日付ごとの行 -->
           <div>
           <% date_range.each_with_index do |date, index| %>
+
+            <%# 日付線の色を決める %>
+            <% date_color = date_line_color(date) %>
+
             <div
               class="h-[40px] border-b border-base-100 z-30
               <%= (index == 0) ? 'border-t' : '' %>
-              <%= (date.mday == 1) ? 'border-t-3 border-t-info' : '' %>
-              <%= today_color(date, "/20") %>
+              <%= (date.mday == 1) ? 'border-t-3 border-t-info' : '' %> <%= date_color %>
               "
               style="width: max(<%= chart_total_width %>px, 100%);"
             >

--- a/app/views/gantt_chart/_chart_layout.html.erb
+++ b/app/views/gantt_chart/_chart_layout.html.erb
@@ -38,7 +38,7 @@
               <% if milestone.is_a?(Milestone) %>
                 <%# milestoneのチャートの場合 %>
 
-                <%= button_to milestone_open_toggle_path(milestone), class: "flex items-center justify-center hover:cursor-pointer hover:bg-base-100/30", method: :patch do %>
+                <%= button_to milestone_open_toggle_path(milestone), class: "flex items-center justify-center hover:cursor-pointer hover:bg-base-100/30", method: :patch, data: { action: "click->loading#show" } do %>
                   <%# milestoneの開閉 %>
                   <% if milestone.open? %>
                     <span id="open_icon_<%=milestone.id%>" class="material-symbols-outlined size-full">

--- a/app/views/limited_sharing_milestones/_share_confirm_modal.html.erb
+++ b/app/views/limited_sharing_milestones/_share_confirm_modal.html.erb
@@ -11,7 +11,9 @@
 
         <%= button_to "公開", limited_sharing_milestones_path(id: @milestone.id),
           method: :post,
-          class: "btn btn-primary text-base-100 px-9" %>
+          class: "btn btn-primary text-base-100 px-9",
+          data: { action: "click->loading#show" }
+        %>
 
       </div>
     </div>

--- a/app/views/milestones/copies/_milestones_copy_modal_content.html.erb
+++ b/app/views/milestones/copies/_milestones_copy_modal_content.html.erb
@@ -5,7 +5,7 @@
         <p class="text-xl">星座をコピーする</p>
       </div>
 
-    <%= form_with model: @milestone, url:milestones_copies_path(id: @milestone.id), method: :post, local: true do |f| %>
+    <%= form_with model: @milestone, url:milestones_copies_path(id: @milestone.id), method: :post, local: true, data: { action: "submit->loading#show" } do |f| %>
       <div class="flex justify-center">
         <label class="mb-8 w-50">
           <span class="text-base-200 text-sm">始点となる日付</span>

--- a/app/views/milestones/copies/create.turbo_stream.erb
+++ b/app/views/milestones/copies/create.turbo_stream.erb
@@ -2,6 +2,10 @@
     <%= render "flash" %>
   <% end %>
 
+  <%= turbo_stream.replace "loading_close" do %>
+    <div id="loading_close" data-controller="loading-close"></div>
+  <% end %>
+
   <% if @copy_success %>
     <%= turbo_stream.replace "copy_icon_#{@milestone.id}" do %>
       <span id="copy_icon_<%=@milestone.id%>" class="material-symbols-outlined">

--- a/app/views/tasks/copies/_tasks_copy_modal_content.html.erb
+++ b/app/views/tasks/copies/_tasks_copy_modal_content.html.erb
@@ -8,7 +8,7 @@
           <p class="text-sm text-base-200">チャートからコピーする場合は、<br>再読み込みするまで表示されません。</p>
         </div>
 
-    <%= form_with model: @task, url:tasks_copies_path(id:@task.id) , method: :post, local: true do |f| %>
+        <%= form_with model: @task, url:tasks_copies_path(id:@task.id) , method: :post, local: true, data: { action: "submit->loading#show" } do |f| %>
       <div class="flex justify-center">
         <label class="mb-8 w-50">
           <span class="text-base-200 text-sm">始点となる日付</span>

--- a/app/views/tasks/copies/create.turbo_stream.erb
+++ b/app/views/tasks/copies/create.turbo_stream.erb
@@ -2,6 +2,10 @@
     <%= render "flash" %>
   <% end %>
 
+  <%= turbo_stream.replace "loading_close" do %>
+    <div id="loading_close" data-controller="loading-close"></div>
+  <% end %>
+
   <% if @copy_success %>
     <%= turbo_stream.prepend "tasks_content" do %>
       <%= render "tasks/task", task: @copy %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,7 +3,7 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   config.hosts << 'hoshi-ni-task-wo.net'
   config.hosts << 'hoshi-ni-task-wo.onrender.com'
-  config.hosts << 'hoshi-ni-task-wo-pr-220.onrender.com'
+  config.hosts << 'hoshi-ni-task-wo-pr-221.onrender.com'
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.


### PR DESCRIPTION
<!-- github copilot レビューは日本語でお願いします -->
# 概要

<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->

本日の日付の色が、土日の色に打ち消される問題を修正。
また、チャートの折りたたみ時、各種コピー時、星座限定公開時にもローディングを追加。

# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイントです -->

  - app
    - helpers
      - gantt_chart_helper.rb (M 10, 0)
        - today_colorメソッドを追加
    - views
      - gantt_chart
        - _chart_layout.html.erb (M 3, 4)
          - 色指定部分をtoday_colorメソッドに変更
          - 折りたたみ切り替えボタンクリック時、ローディングを表示
        - _chart.html.erb 1, 1
      - limited_sharing_milestones
        - _share_confirm_modal.html.erb 3, 1
          - 共有時にローディング
      - milestones/copies
        - _milestones_copy_modal_content.html.erb 1, 1
          - copy時にローディング
        - create.turbo_stream.erb 4, 0
          - ローディングを閉じる要素を置換
      - tasks/copies
        - _tasks_copy_modal_content.html.erb 1, 1
          - copy時にローディング
        - create.turbo_stream.erb 4, 0
          - ローディングを閉じる要素を置換


<!-- github copilot レビューは日本語でお願いします -->
