### PR TITLE
モーダルに再度blurを追加

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -99,3 +99,10 @@
 .btn:active {
   opacity: 0.5;
 }
+
+.modal {
+  backdrop-filter: blur(3px);
+}
+.not_blur {
+  backdrop-filter: none;
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -16,5 +16,8 @@ application.register("loading-close", LoadingCloseController)
 import LoadingController from "./loading_controller"
 application.register("loading", LoadingController)
 
+import ModalController from "./modal_controller"
+application.register("modal", ModalController)
+
 import ShowModalController from "./show_modal_controller"
 application.register("show-modal", ShowModalController)

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,0 +1,26 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="modal"
+export default class extends Controller {
+  static targets = ["to_not_blur", "slide_top", "close"]
+
+  connect() {
+    document.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") {
+        this.to_not_blurTarget.classList.add("not_blur");
+        setTimeout(() => {
+          this.to_not_blurTarget.classList.remove("not_blur");
+        }, 500);
+      }
+    });
+
+    this.closeTargets.forEach((closeTarget) => {
+      closeTarget.addEventListener("click", () => {
+        this.to_not_blurTarget.classList.add("not_blur");
+        setTimeout(() => {
+          this.to_not_blurTarget.classList.remove("not_blur");
+        }, 500);
+      });
+    });
+  }
+}

--- a/app/views/devise/registrations/_edit_form_modal.html.erb
+++ b/app/views/devise/registrations/_edit_form_modal.html.erb
@@ -1,72 +1,70 @@
 <%# @modal_openはregistrations_controller.rbで定義 %>
 <%# update失敗時にrender users/showを行う際にモーダルが閉じてしまうことを回避 %>
-<dialog id="edit_modal" class="modal" <%= @modal_open ? 'open' : ' ' %> >
-  <div class="modal-box w-xl max-h-[90dvh] max-w-[85dvw] text-xs md:text-sm p-1 bg-transparent text-base-100">
-    <div class="flex items-center justify-center">
-      <div class="card bg-base-300 w-2xl h-2xl p-5 flex justify-center z-10">
-        <div>
+<div data-controller="modal">
+  <dialog data-modal-target="to_not_blur" id="edit_modal" class="modal" <%= @modal_open ? 'open' : ' ' %> >
+    <div class="modal-box w-xl max-h-[90dvh] max-w-[85dvw] text-xs md:text-sm p-1 text-base-100 card bg-base-300 w-2xl h-2xl p-5 flex justify-center z-10">
+      <div>
 
-          <!-- エラーメッセージ -->
-          <%= render "error_messages", resource: @user %>
+        <!-- エラーメッセージ -->
+        <%= render "error_messages", resource: @user %>
 
-          <!-- 編集フォーム -->
-          <%= form_for(@user, as: @user, url: registration_path(@user), html: { method: :put, class: "w-full mt-2 p-2" }, data: { action: "submit->loading#show" }) do |f| %>
+        <!-- 編集フォーム -->
+        <%= form_for(@user, as: @user, url: registration_path(@user), html: { method: :put, class: "w-full mt-2 p-2" }, data: { action: "submit->loading#show" }) do |f| %>
 
-            <label class="floating-label">
-              <%= f.text_field :name,
-                autofocus: true,
-                autocomplete: "name",
-                placeholder: "ユーザーネーム*",
-                required: true,
-                class: "input input-sm md:input-lg input-primary w-full bg-base-200" %>
-                <span class="floating-label-text text-base-200">ユーザーネーム*</span>
-            </label>
+          <label class="floating-label">
+            <%= f.text_field :name,
+              autofocus: true,
+              autocomplete: "name",
+              placeholder: "ユーザーネーム*",
+              required: true,
+              class: "input input-sm md:input-lg input-primary w-full bg-base-200" %>
+            <span class="floating-label-text text-base-200">ユーザーネーム*</span>
+          </label>
 
-            <label class="floating-label mt-5">
-              <%= f.text_field :email,
-                autocomplete: "email",
-                placeholder: "メールアドレス*",
-                required: true,
-                class: "input input-sm md:input-lg input-primary w-full bg-base-200" %>
-                <span class="floating-label-text text-base-200">メールアドレス*</span>
-            </label>
+          <label class="floating-label mt-5">
+            <%= f.text_field :email,
+              autocomplete: "email",
+              placeholder: "メールアドレス*",
+              required: true,
+              class: "input input-sm md:input-lg input-primary w-full bg-base-200" %>
+            <span class="floating-label-text text-base-200">メールアドレス*</span>
+          </label>
 
-            <label class="floating-label mt-5">
-              <%= f.text_area :bio,
-                autocomplete: "bio",
-                placeholder: "自己紹介",
-                class: "textarea textarea-sm md:textarea-lg input-primary w-full bg-base-200 rounded-lg" %>
-                <span class="floating-label-text text-base-200">自己紹介</span>
-            </label>
+          <label class="floating-label mt-5">
+            <%= f.text_area :bio,
+              autocomplete: "bio",
+              placeholder: "自己紹介",
+              class: "textarea textarea-sm md:textarea-lg input-primary w-full bg-base-200 rounded-lg" %>
+            <span class="floating-label-text text-base-200">自己紹介</span>
+          </label>
 
-            <div class="mt-6">
-              <%= f.submit "保存",
-                class:"btn btn-secondary w-full text-base-100" %>
-            </div>
-          <% end %>
-
-          <div class="divider text-base-200">ユーザー削除</div>
-
-          <div class="flex flex-col items-center">
-            <%= button_to "アカウントを削除する", 
-              registration_path(@user), 
-              data: { confirm: "本当に削除しますか？", turbo_confirm: "本当に削除しますか？" }, 
-              method: :delete, 
-              class: "btn btn-error w-full text-xs md:text-sm" %>
+          <div class="mt-6">
+            <%= f.submit "保存",
+              class:"btn btn-secondary w-full text-base-100" %>
           </div>
-          <div class="divider"></div>
+        <% end %>
 
-          <div class="modal-action flex justify-center mt-5">
-            <form method="dialog">
-              <button class="btn btn-accent px-3">
-                <span class="material-symbols-outlined">
-                  close
-                </span>
-              </button>
-            </form>
-          </div>
+        <div class="divider text-base-200">ユーザー削除</div>
+
+        <div class="flex flex-col items-center">
+          <%= button_to "アカウントを削除する", 
+            registration_path(@user), 
+            data: { confirm: "本当に削除しますか？", turbo_confirm: "本当に削除しますか？" }, 
+            method: :delete, 
+            class: "btn btn-error w-full text-xs md:text-sm" %>
+        </div>
+        <div class="divider"></div>
+
+        <div class="modal-action flex justify-center mt-5">
+          <form method="dialog">
+            <button data-modal-target="close" class="btn btn-accent px-3">
+              <span class="material-symbols-outlined">
+                close
+              </span>
+            </button>
+          </form>
         </div>
       </div>
     </div>
-  </div>
-</dialog>
+  </dialog>
+</div>

--- a/app/views/gantt_chart/milestone_show.html.erb
+++ b/app/views/gantt_chart/milestone_show.html.erb
@@ -1,7 +1,8 @@
 <%= turbo_frame_tag "milestone_show_modal" do %>
   <div data-controller="show-modal">
+  <div data-controller="modal">
     <div data-show-modal-target="modal_top">
-      <dialog data-show-modal-target="task_modal" id="milestone_show_modal" class="modal" <%= @tasks_show_modal_open ? 'open' : ' ' %> >
+      <dialog data-modal-target="to_not_blur" data-show-modal-target="task_modal" id="milestone_show_modal" class="modal" <%= @tasks_show_modal_open ? 'open' : ' ' %> >
         <div class="modal-box w-xl max-h-[95dvh] max-w-[85dvw] text-xs md:text-sm p-1 bg-transparent">
           <div class="flex items-center justify-center">
             <div class="card z-10 flex h-2xl w-full justify-center bg-base-300 p-5 text-center md:w-2xl text-base-300">
@@ -107,7 +108,7 @@
 
                 <div class="modal-action flex justify-center mt-7">
                   <form method="dialog">
-                    <button class="btn btn-accent size-9">
+                    <button data-modal-target="close" class="btn btn-accent size-9">
                       <span class="material-symbols-outlined">
                         close
                       </span>
@@ -119,9 +120,10 @@
           </div>
         </div>
         <form method="dialog" class="modal-backdrop">
-          <button>close</button>
+          <button data-modal-target="close">close</button>
         </form>
       </dialog>
     </div>
+  </div>
   </div>
 <% end %>

--- a/app/views/limited_sharing_milestones/_share_confirm_modal.html.erb
+++ b/app/views/limited_sharing_milestones/_share_confirm_modal.html.erb
@@ -1,4 +1,5 @@
-<dialog id="share_confirm_modal" class="modal">
+<div data-controller="modal">
+<dialog data-modal-target="to_not_blur" id="share_confirm_modal" class="modal">
   <div class="modal-box w-sm max-h-[90vh] max-w-[85dvw] px-2">
     <div class="flex w-full items-center justify-center">
       <div class="card z-10 flex h-2xl w-full justify-center bg-base-300 p-5 px-0 md:px-5 text-center md:w-2xl">
@@ -19,7 +20,7 @@
     </div>
   <div class="modal-action flex justify-center">
     <form method="dialog">
-      <button class="btn btn-accent px-9">
+      <button data-modal-target="close" class="btn btn-accent px-9">
         キャンセル
       </button>
     </form>
@@ -29,6 +30,7 @@
 
 
   <form method="dialog" class="modal-backdrop">
-    <button>close</button>
+    <button data-modal-target="close">close</button>
   </form>
 </dialog>
+</div>

--- a/app/views/milestones/_milestones_edit_modal.html.erb
+++ b/app/views/milestones/_milestones_edit_modal.html.erb
@@ -1,4 +1,5 @@
-<dialog id="milestones_edit_modal" class="modal" <%= @milestones_edit_modal_open ? 'open' : ' ' %> >
+<div data-controller="modal">
+<dialog data-modal-target="to_not_blur" id="milestones_edit_modal" class="modal" <%= @milestones_edit_modal_open ? 'open' : ' ' %> >
   <div class="modal-box w-xl max-h-[90dvh] max-w-[85dvw] text-xs md:text-sm p-1 bg-transparent">
     <div class="flex items-center justify-center">
       <div class="card bg-base-300 w-xl h-2xl p-5 flex justify-center z-10">
@@ -85,7 +86,7 @@
           
           <div class="modal-action flex justify-center mt-3">
             <form method="dialog">
-              <button class="btn btn-accent size-9">
+              <button data-modal-target="close" class="btn btn-accent size-9">
                 <span class="material-symbols-outlined">
                   close
                 </span>
@@ -97,3 +98,4 @@
     </div>
   </div>
 </dialog>
+</div>

--- a/app/views/milestones/_milestones_new_modal.html.erb
+++ b/app/views/milestones/_milestones_new_modal.html.erb
@@ -1,4 +1,5 @@
-<dialog id="milestones_new_modal" class="modal" <%= @milestones_new_modal_open ? 'open' : ' ' %> >
+<div data-controller="modal">
+<dialog data-modal-target="to_not_blur" id="milestones_new_modal" class="modal" <%= @milestones_new_modal_open ? 'open' : ' ' %> >
   <div class="modal-box w-xl max-h-[90dvh] max-w-[85dvw] text-xs md:text-sm p-1 bg-transparent">
     <div class="flex items-center justify-center">
       <div class="card bg-base-300 size-full p-5 flex justify-center z-10">
@@ -90,7 +91,7 @@
 
           <div class="modal-action flex justify-center mt-3">
             <form method="dialog">
-              <button class="btn btn-sm btn-accent px-2">
+              <button data-modal-target="close" class="btn btn-sm btn-accent px-2">
                 <span class="material-symbols-outlined">
                   close
                 </span>
@@ -103,3 +104,4 @@
   </div>
 
 </dialog>
+</div>

--- a/app/views/milestones/copies/_milestones_copy_modal_content.html.erb
+++ b/app/views/milestones/copies/_milestones_copy_modal_content.html.erb
@@ -24,7 +24,7 @@
   </div>
       <div class="modal-action flex justify-center">
       <form method="dialog">
-        <button class="btn btn-accent px-9">
+        <button data-modal-target="close" class="btn btn-accent px-9">
           <span class="material-symbols-outlined">
             close
           </span>

--- a/app/views/milestones/copies/show.html.erb
+++ b/app/views/milestones/copies/show.html.erb
@@ -1,17 +1,19 @@
 <%= turbo_frame_tag "milestones_copy_modal" do %>
   <div data-controller="show-modal">
+  <div data-controller="modal">
     <div data-show-modal-target="modal_top">
-      <dialog data-show-modal-target="task_modal" class="modal">
+      <dialog data-modal-target="to_not_blur" data-show-modal-target="task_modal" class="modal">
 
         <%# まずはturbo_frame_tagを使ってmilestones/copies/showでモーダルの部分を表示 %>
         <%# milestones/copies#createでturbo_stremasを使って、モーダルの部分を_milestones_copy_modal_contentファイルに置換しています %>
 
         <%= render "milestones/copies/milestones_copy_modal_content", task: @task %>
 
-        <form method="dialog" class="modal-backdrop">
+        <form data-modal-target="close" method="dialog" class="modal-backdrop">
           <button>close</button>
         </form>
       </dialog>
+    </div>
     </div>
   </div>
 <% end %>

--- a/app/views/tasks/_tasks_new_modal.html.erb
+++ b/app/views/tasks/_tasks_new_modal.html.erb
@@ -11,8 +11,8 @@
   end
 %>
 
-<div id="tasks_new_stream_target">
-  <dialog id="tasks_new_modal" class="modal" <%= @task_new_modal_open ? 'open' : ' ' %> >
+<div data-controller="modal" id="tasks_new_stream_target">
+  <dialog data-modal-target="to_not_blur" id="tasks_new_modal" class="modal" <%= @task_new_modal_open ? 'open' : ' ' %> >
 
     <div class="modal-box w-xl max-h-[90dvh] max-w-[85dvw] text-xs md:text-sm p-1 bg-transparent">
       <div class="flex items-center justify-center">
@@ -128,7 +128,7 @@
 
             <div class="modal-action flex justify-center mt-3">
               <form method="dialog">
-                <button class="btn btn-accent size-9">
+                <button data-modal-target="close" class="btn btn-accent size-9">
                   <span class="material-symbols-outlined">
                     close
                   </span>

--- a/app/views/tasks/_tasks_show_modal.html.erb
+++ b/app/views/tasks/_tasks_show_modal.html.erb
@@ -1,12 +1,14 @@
 <%= turbo_frame_tag "tasks_show_modal_#{@task.id}" do %>
-  <dialog id="tasks_show_modal_<%= @task.id %>_target" class="modal" <%= tasks_show_modal_open ? 'open' : ' ' %> >
+  <div data-controller="modal">
+    <dialog data-modal-target="to_not_blur" id="tasks_show_modal_<%= @task.id %>_target" class="modal" <%= tasks_show_modal_open ? 'open' : ' ' %> >
 
-        <%# まずはturbo_frame_tagを使ってtasks/showでモーダルの部分を表示 %>
-        <%# tasks#updateでturbo_stremasを使って、モーダルの部分をこのファイルに更新しています %>
-        <%= render "tasks/tasks_show_modal_content", task: @task %>
+      <%# まずはturbo_frame_tagを使ってtasks/showでモーダルの部分を表示 %>
+      <%# tasks#updateでturbo_stremasを使って、モーダルの部分をこのファイルに更新しています %>
+      <%= render "tasks/tasks_show_modal_content", task: @task %>
 
-        <form method="dialog" class="modal-backdrop">
-          <button>close</button>
-        </form>
-      </dialog>
+      <form data-modal-target="close" method="dialog" class="modal-backdrop">
+        <button>close</button>
+      </form>
+    </dialog>
+  </div>
 <% end %>

--- a/app/views/tasks/_tasks_show_modal_content.html.erb
+++ b/app/views/tasks/_tasks_show_modal_content.html.erb
@@ -189,7 +189,7 @@
 
         <div class="modal-action flex justify-center mt-3">
           <form method="dialog">
-            <button class="btn btn-accent size-9">
+            <button data-modal-target="close" class="btn btn-accent size-9">
               <span class="material-symbols-outlined">
                 close
               </span>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,13 +1,15 @@
 <%= turbo_frame_tag "tasks_show_modal_#{@task.id}" do %>
-  <dialog id="tasks_show_modal_<%= @task.id %>_target" class="modal" <%= @tasks_show_modal_open ? 'open' : ' ' %> >
+  <div data-controller="modal">
+    <dialog data-modal-target="to_not_blur" id="tasks_show_modal_<%= @task.id %>_target" class="modal" <%= @tasks_show_modal_open ? 'open' : ' ' %> >
 
-    <%# まずはturbo_frame_tagを使ってtasks/showでモーダルの部分を表示 %>
-    <%# tasks#updateでturbo_stremasを使って、モーダルの部分を_tasks_showファイルに置換しています %>
+      <%# まずはturbo_frame_tagを使ってtasks/showでモーダルの部分を表示 %>
+      <%# tasks#updateでturbo_stremasを使って、モーダルの部分を_tasks_showファイルに置換しています %>
 
-    <%= render "tasks/tasks_show_modal_content", task: @task %>
+      <%= render "tasks/tasks_show_modal_content", task: @task %>
 
-    <form method="dialog" class="modal-backdrop">
-      <button>close</button>
-    </form>
-  </dialog>
+      <form data-modal-target="close" method="dialog" class="modal-backdrop">
+        <button>close</button>
+      </form>
+    </dialog>
+  </div>
 <% end %>


### PR DESCRIPTION
<!-- github copilot レビューは日本語でお願いします -->
# 概要
<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->

モーダル背景に再度blurを追加しました。
blurがあるとモーダルを閉じた後すこしのあいだ背景が見えなかったので削除しましたが、閉じる動作時すぐに背景のblurを取り除くことで解決できたので、再度追加しました。


# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイントです -->


- app
  - assets/stylesheets
    - application.tailwind.css [M] 7, 0
      - .modalにblurを追加し、blurを無効化する.not_blurを追加
  - javascript/controllers
    - index.js [M] 3, 0
      - modal_controller追加時に自動で記載
    - modal_controller.js [A] 26, 0
      - 接続時に、その要素内のdialogと閉じる動作をリッスンし、即座にblurを取り除く

以下はstimulusと接続した記載
  - views
    - devise/registrations
      - _edit_form_modal.html.erb [M] 56, 58
    - gantt_chart
      - milestone_show.html.erb [M] 5, 3
    - limited_sharing_milestones
      - _share_confirm_modal.html.erb [M] 5, 3
    - milestones
      - copies
        - _milestones_copy_modal_content.html.erb [M] 1, 1
        - show.html.erb [M] 4, 2
      - _milestones_edit_modal.html.erb [M] 4, 2
      - _milestones_new_modal.html.erb [M] 4, 2
    - tasks
      - _tasks_new_modal.html.erb [M] 3, 3
      - _tasks_show_modal.html.erb [M] 10, 8
      - _tasks_show_modal_content.html.erb [M] 1, 1
      - show.html.erb [M] 10, 8


<!-- github copilot レビューは日本語でお願いします -->

