### PR TITLE
deviseのログインが、ブラウザを落としても持続するように

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -3,7 +3,7 @@
   <%= render "flash" %>
 </div>
 
-<div class="flex items-center justify-center min-h-screen px-6">
+<div class="flex items-center justify-center min-h-screen px-6 my-5">
   <div class="card bg-base-300 w-2xl h-2xl p-10 flex justify-center z-10">
     <div>
       <!-- ロゴ -->
@@ -66,7 +66,7 @@
         <% end %>
 
         <div class="mt-6">
-          <%= f.submit "登録", class:"btn btn-secondary w-full text-base-200" %>
+          <%= f.submit "登録", class:"btn btn-secondary w-full text-base-100" %>
         </div>
       <% end %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -41,7 +41,12 @@
           <span class="floating-label-text">パスワード</span>
         </label>
 
-        <%= f.submit "ログイン", class: "btn btn-secondary text-base-200 w-full mt-8" %>
+        <%= f.submit "ログイン", class: "btn btn-secondary text-base-100 w-full mt-8" %>
+
+        <%= f.label :remember_me, class: "flex w-full items-center justify-center hover:cursor-pointer mt-5" do %>
+          <%= f.check_box :remember_me, class: "checkbox checkbox-primary bg-base-100" %>
+          <span class="ml-2">ログイン状態を保持する</span>
+        <% end %>
       <% end %>
 
       <div class="my-8 text-center space-y-2">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -45,7 +45,7 @@
 
         <%= f.label :remember_me, class: "flex w-full items-center justify-center hover:cursor-pointer mt-5" do %>
           <%= f.check_box :remember_me, class: "checkbox checkbox-primary bg-base-100" %>
-          <span class="ml-2">ログイン状態を保持する</span>
+          <span class="ml-2"><%= I18n.t('devise.sessions.new.remember_me') %></span>
         <% end %>
       <% end %>
 

--- a/app/views/static_pages/_auth_buttons.html.erb
+++ b/app/views/static_pages/_auth_buttons.html.erb
@@ -1,7 +1,7 @@
 <% if user_signed_in? %>
   <div class="relative z-10">
     <div class="flex justify-center items-center">
-      <%= link_to "ユーザーページへ", user_path(current_user), class: "btn btn-primary w-42 h-12" %>
+      <%= link_to "ユーザーページへ", user_path(current_user), class: "btn btn-primary w-42 h-12 text-base-100" %>
     </div>
   </div>
 <% else %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -164,17 +164,17 @@ Devise.setup do |config|
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
-  # config.remember_for = 2.weeks
+  config.remember_for = 2.weeks
 
   # Invalidates all the remember me tokens when the user signs out.
-  config.expire_all_remember_me_on_sign_out = true
+  config.expire_all_remember_me_on_sign_out = false
 
   # If true, extends the user's remember period when remembered via cookie.
-  # config.extend_remember_period = false
+  config.extend_remember_period = true
 
   # Options to be passed to the created cookie. For instance, you can set
   # secure: true in order to force SSL only cookies.
-  # config.rememberable_options = {}
+  config.rememberable_options = { secure: true }
 
   # ==> Configuration for :validatable
   # Range for password length.

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,65 +1,102 @@
-# Additional translations at https://github.com/heartcombo/devise/wiki/I18n
-
 en:
-  devise:
-    confirmations:
-      confirmed: "Your email address has been successfully confirmed."
-      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
-      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
-    failure:
-      already_authenticated: "You are already signed in."
-      inactive: "Your account is not activated yet."
-      invalid: "Invalid %{authentication_keys} or password."
-      locked: "Your account is locked."
-      last_attempt: "You have one more attempt before your account is locked."
-      not_found_in_database: "Invalid %{authentication_keys} or password."
-      timeout: "Your session expired. Please sign in again to continue."
-      unauthenticated: "You need to sign in or sign up before continuing."
-      unconfirmed: "You have to confirm your email address before continuing."
-    mailer:
-      confirmation_instructions:
-        subject: "Confirmation instructions"
-      reset_password_instructions:
-        subject: "Reset password instructions"
-      unlock_instructions:
-        subject: "Unlock instructions"
-      email_changed:
-        subject: "Email Changed"
-      password_change:
-        subject: "Password Changed"
-    omniauth_callbacks:
-      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
-      success: "Successfully authenticated from %{kind} account."
-    passwords:
-      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
-      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
-      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
-      updated: "Your password has been changed successfully. You are now signed in."
-      updated_not_active: "Your password has been changed successfully."
-    registrations:
-      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
-      signed_up: "Welcome! You have signed up successfully."
-      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
-      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
-      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
-      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
-      updated: "Your account has been updated successfully."
-      updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again."
-    sessions:
-      signed_in: "Signed in successfully."
-      signed_out: "Signed out successfully."
-      already_signed_out: "Signed out successfully."
-    unlocks:
-      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
-      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
-      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
   errors:
     messages:
-      already_confirmed: "was already confirmed, please try signing in"
-      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
-      expired: "has expired, please request a new one"
-      not_found: "not found"
-      not_locked: "was not locked"
       not_saved:
-        one: "1 error prohibited this %{resource} from being saved:"
-        other: "%{count} errors prohibited this %{resource} from being saved:"
+        one: "1 error occurred, %{resource} could not be saved."
+        other: "%{count} errors occurred, %{resource} could not be saved."
+  activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            name:
+              taken: "is already in use."
+              blank: "is not entered."
+              too_short: "is too short (minimum is %{count} characters)."
+              too_long: "is too long (maximum is %{count} characters)."
+              invalid: "is invalid."
+            email:
+              taken: "is already in use."
+              blank: "is not entered."
+              too_short: "is too short (minimum is %{count} characters)."
+              too_long: "is too long (maximum is %{count} characters)."
+              invalid: "is invalid."
+            password:
+              taken: "is already in use."
+              blank: "is not entered."
+              too_short: "is too short (minimum is %{count} characters)."
+              too_long: "is too long (maximum is %{count} characters)."
+              invalid: "is invalid."
+              confirmation: "doesn't match content."
+            password_confirmation:
+              confirmation: "doesn't match password."
+              blank: "is not entered."
+    attributes:
+      user:
+        current_password: "Current password"
+        name: "Name"
+        email: "Email address"
+        password: "Password"
+        password_confirmation: "Password confirmation"
+        remember_me: "Remember me"
+    models:
+      user: "User"
+      milestone: "Milestone"
+      task: "Task"
+  devise:
+    confirmations:
+      new:
+        resend_confirmation_instructions: "Resend confirmation instructions"
+    mailer:
+      confirmation_instructions:
+        action: "Confirm account"
+        greeting: "Welcome, %{recipient}!"
+        instruction: "You can confirm your email address through the link below:"
+      reset_password_instructions:
+        action: "Change password"
+        greeting: "Hello, %{recipient}!"
+        instruction: "Someone has requested a link to change your password. You can do this through the link below."
+        instruction_2: "If you didn't request this, please ignore this email."
+        instruction_3: "Your password won't change until you access the link above and create a new one."
+      unlock_instructions:
+        action: "Unlock account"
+        greeting: "Hello, %{recipient}!"
+        instruction: "Click the link below to unlock your account:"
+        message: "Your account has been locked due to an excessive number of unsuccessful sign in attempts."
+    passwords:
+      edit:
+        change_my_password: "Change my password"
+        change_your_password: "Change your password"
+        confirm_new_password: "Confirm new password"
+        new_password: "New password"
+      new:
+        forgot_your_password: "Forgot your password?"
+        send_me_reset_password_instructions: "Send me reset password instructions"
+    registrations:
+      edit:
+        are_you_sure: "Are you sure?"
+        cancel_my_account: "Cancel my account"
+        currently_waiting_confirmation_for_email: "Currently waiting confirmation for: %{email}"
+        leave_blank_if_you_don_t_want_to_change_it: "leave blank if you don't want to change it"
+        title: "Edit %{resource}"
+        unhappy: "Unhappy"
+        update: "Update"
+        we_need_your_current_password_to_confirm_your_changes: "we need your current password to confirm your changes"
+      new:
+        sign_up: "Sign up"
+    sessions:
+      new:
+        sign_in: "Sign in"
+        remember_me: "Remember me"
+    shared:
+      links:
+        back: "Back"
+        didn_t_receive_confirmation_instructions: "Didn't receive confirmation instructions?"
+        didn_t_receive_unlock_instructions: "Didn't receive unlock instructions?"
+        forgot_your_password: "Forgot your password?"
+        sign_in: "Sign in"
+        sign_in_with_provider: "Sign in with %{provider}"
+        sign_up: "Sign up"
+    unlocks:
+      new:
+        resend_unlock_instructions: "Resend unlock instructions"

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -87,6 +87,7 @@ ja:
     sessions:
       new:
         sign_in: "ログイン"
+        remember_me: "次回から自動的にログイン"
     shared:
       links:
         back: "戻る"


### PR DESCRIPTION
<!-- github copilot レビューは日本語でお願いします -->
# 概要

<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->

deviseのログインを、ブラウザを落としても持続するように変更しました

# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイントです -->

  - app/views
    - devise
      - registrations
        - M: new.html.erb (2, 2)
          - 上下にマージンを追加、文字色変更
      - sessions
        - M: new.html.erb (6, 1)
          - ログインを保持するチェックを追加
    - static_pages
      - M: _auth_buttons.html.erb (1, 1)
        - 文字色変更
  - config/initializers
    - M: devise.rb (4, 4)
      - 他でログアウトしたときに全部ログアウトしないように
      - ログインするたびにログイン持続時間をリセット
      - httpsのみ持続するよう


<!-- github copilot レビューは日本語でお願いします -->

