### PR TITLE
gem rails-erdを導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@
 !/app/assets/builds/.keep
 
 /node_modules
+
+/coverage

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@
 /node_modules
 
 /coverage
+/erd.pdf

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -9,7 +9,7 @@ RUN apt-get update -qq \
 && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
 && wget --quiet -O - /tmp/pubkey.gpg https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
 && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs yarn vim
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs yarn vim graphviz
 RUN mkdir /myapp
 WORKDIR /myapp
 RUN gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -49,8 +49,6 @@ gem "nanoid"
 
 gem "ransack"
 
-gem "rails-erd"
-
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
@@ -68,6 +66,8 @@ group :development, :test do
   gem 'rspec-rails', '~> 7.1.1'
   gem 'factory_bot_rails'
   gem 'faker'
+
+  gem "rails-erd"
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -66,13 +66,12 @@ group :development, :test do
   gem 'rspec-rails', '~> 7.1.1'
   gem 'factory_bot_rails'
   gem 'faker'
-
-  gem "rails-erd"
 end
 
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+  gem "rails-erd"
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,8 @@ gem "nanoid"
 
 gem "ransack"
 
+gem "rails-erd"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    choice (0.2.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     crass (1.0.6)
@@ -279,6 +280,11 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
+    rails-erd (1.7.2)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
+      choice (~> 0.2.0)
+      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
@@ -353,6 +359,8 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.38.0, < 2.0)
+    ruby-graphviz (1.2.5)
+      rexml
     ruby-progressbar (1.13.0)
     rubyzip (2.4.1)
     securerandom (0.4.1)
@@ -463,6 +471,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rack-mini-profiler
   rails (~> 7.2.2, >= 7.2.2.1)
+  rails-erd
   ransack
   rspec-rails (~> 7.1.1)
   rubocop


### PR DESCRIPTION
<!-- github copilot レビューは日本語でお願いします -->
# 概要
<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->

gem rails-erdをインストールしました
これにより、schemaファイルからER図を生成することが出来ます。
ER図を最新のものに更新するにあたって、見やすいモノを一度出力するために導入しました。

# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイントです -->

- .gitignore 3, 0
  - rails-erdにより生成される/coverageと/erd.pdfをgitignoreに追加
- Dockerfile.dev 1, 1
  - rails-erdの依存先である、graphvizをインストール
- Gemfile 2, 0
  - rails-erd追加


## スクリーンショット
![image](https://github.com/user-attachments/assets/29c3e480-c07a-40bc-9ab7-ac29ffb65b5f)

<!-- Command + Shift + Control + 4 でスクリーンショットして Command + V でここに貼り付けるのが楽。以下のテーブルは必要に応じて使ってください -->

<!-- github copilot レビューは日本語でお願いします -->

