### PR TITLE
Refact/line omniauth

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -13,8 +13,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   private
 
-  # rubocop:disable Style/RedundantCondition
-  # rubocop:disable Layout/LineLength
   def basic_action
     @omniauth = request.env["omniauth.auth"]
     if @omniauth.present?
@@ -22,19 +20,26 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       if @profile.email.blank?
         random_id = Nanoid.generate(size: NanoidGenerator::ID_LENGTH, alphabet: NanoidGenerator::ID_ALPHABET)
         email = "#{random_id}-#{@omniauth['provider']}@example.com"
-        @profile = current_user || User.create!(provider: @omniauth["provider"], uid: @omniauth["uid"], email: email, name: @omniauth["info"]["name"], password: Devise.friendly_token[0, 20])
+        @profile = current_user || User.create!(
+          provider: @omniauth["provider"],
+          uid: @omniauth["uid"],
+          email: email,
+          name: @omniauth["info"]["name"],
+          password: Devise.friendly_token[0, 20]
+        )
       end
       @profile.remember_me = true
       sign_in(:user, @profile)
-      UserRegistration::MakeTasksMilestones.create_tasks_and_milestones(@profile) if @profile.tasks.empty? && @profile.milestones.empty?
+
+      if @profile.tasks.empty? && @profile.milestones.empty?
+        UserRegistration::MakeTasksMilestones.create_tasks_and_milestones(@profile)
+      end
     end
 
     # ログイン後のflash messageとリダイレクト先を設定
     flash[:notice] = "ログインしました"
     redirect_to user_path(current_user)
   end
-  # rubocop:enable Style/RedundantCondition
-  # rubocop:enable Layout/LineLength
 
   # rubocop:disable Lint/UnusedMethodArgument
   def fake_email(uid, provider)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -40,7 +40,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     redirect_to user_path(current_user)
   end
 
-  # rubocop:disable Lint/UnusedMethodArgument
   def fake_email(provider)
     random_id = Nanoid.generate(size: NanoidGenerator::ID_LENGTH, alphabet: NanoidGenerator::ID_ALPHABET)
     "#{random_id}-#{provider}@example.com"
@@ -66,4 +65,3 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     redirect_to user_path(current_user)
   end
 end
-# rubocop:enable Lint/UnusedMethodArgument

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -43,7 +43,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # rubocop:disable Lint/UnusedMethodArgument
   def fake_email(provider)
     random_id = Nanoid.generate(size: NanoidGenerator::ID_LENGTH, alphabet: NanoidGenerator::ID_ALPHABET)
-    "#{random_id}-#{@omniauth['provider']}@example.com"
+    "#{random_id}-#{provider}@example.com"
   end
 
   def link_line_account

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -18,8 +18,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     if @omniauth.present?
       @profile = User.find_or_initialize_by(provider: @omniauth["provider"], uid: @omniauth["uid"])
       if @profile.email.blank?
-        random_id = Nanoid.generate(size: NanoidGenerator::ID_LENGTH, alphabet: NanoidGenerator::ID_ALPHABET)
-        email = "#{random_id}-#{@omniauth['provider']}@example.com"
+        email = fake_email(@omniauth["provider"])
         @profile = current_user || User.create!(
           provider: @omniauth["provider"],
           uid: @omniauth["uid"],
@@ -42,8 +41,9 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   # rubocop:disable Lint/UnusedMethodArgument
-  def fake_email(uid, provider)
-    "#{auth.uid}-#{auth.provider}@example.com"
+  def fake_email(provider)
+    random_id = Nanoid.generate(size: NanoidGenerator::ID_LENGTH, alphabet: NanoidGenerator::ID_ALPHABET)
+    "#{random_id}-#{@omniauth['provider']}@example.com"
   end
 
   def link_line_account

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -20,7 +20,8 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     if @omniauth.present?
       @profile = User.find_or_initialize_by(provider: @omniauth["provider"], uid: @omniauth["uid"])
       if @profile.email.blank?
-        email = @omniauth["info"]["email"] ? @omniauth["info"]["email"] : "#{@omniauth['uid']}-#{@omniauth['provider']}@example.com"
+        random_id = Nanoid.generate(size: NanoidGenerator::ID_LENGTH, alphabet: NanoidGenerator::ID_ALPHABET)
+        email = "#{random_id}-#{@omniauth['provider']}@example.com"
         @profile = current_user || User.create!(provider: @omniauth["provider"], uid: @omniauth["uid"], email: email, name: @omniauth["info"]["name"], password: Devise.friendly_token[0, 20])
       end
       @profile.set_values(@omniauth)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -24,7 +24,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
         email = "#{random_id}-#{@omniauth['provider']}@example.com"
         @profile = current_user || User.create!(provider: @omniauth["provider"], uid: @omniauth["uid"], email: email, name: @omniauth["info"]["name"], password: Devise.friendly_token[0, 20])
       end
-      @profile.set_values(@omniauth)
       @profile.remember_me = true
       sign_in(:user, @profile)
       UserRegistration::MakeTasksMilestones.create_tasks_and_milestones(@profile) if @profile.tasks.empty? && @profile.milestones.empty?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,15 +24,6 @@ class User < ApplicationRecord
     social_profiles.select { |sp| sp.provider == provider.to_s }.first
   end
 
-  # rubocop:disable Style/RedundantSelf
-  def set_values_by_raw_info(raw_info)
-    self.raw_info = raw_info.to_json
-    self.save!
-  end
-  # rubocop:enable Naming/AccessorMethodName
-  # rubocop:enable Style/RedundantSelf
-  #
-
   # ゲストユーザー
   def self.guest
     create do |user|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,21 +24,6 @@ class User < ApplicationRecord
     social_profiles.select { |sp| sp.provider == provider.to_s }.first
   end
 
-  # rubocop:disable Naming/AccessorMethodName
-  def set_values(omniauth)
-    return if provider.to_s != omniauth["provider"].to_s || uid != omniauth["uid"]
-
-    credentials = omniauth["credentials"]
-    info = omniauth["info"]
-
-    # rubocop:disable Lint/UselessAssignment
-    access_token = credentials["refresh_token"]
-    access_secret = credentials["secret"]
-    credentials = credentials.to_json
-    name = info["name"]
-    # rubocop:enable Lint/UselessAssignment
-  end
-
   # rubocop:disable Style/RedundantSelf
   def set_values_by_raw_info(raw_info)
     self.raw_info = raw_info.to_json

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,11 +19,6 @@ class User < ApplicationRecord
 
   scope :notifications_enabled, -> { where(is_notifications_enabled: true) }
 
-  # Lineログイン用の設定
-  def social_profile(provider)
-    social_profiles.select { |sp| sp.provider == provider.to_s }.first
-  end
-
   # ゲストユーザー
   def self.guest
     create do |user|

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,7 +3,7 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   config.hosts << 'hoshi-ni-task-wo.net'
   config.hosts << 'hoshi-ni-task-wo.onrender.com'
-  config.hosts << 'hoshi-ni-task-wo-pr-236.onrender.com'
+  config.hosts << 'hoshi-ni-task-wo-pr-249.onrender.com'
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -167,36 +167,6 @@ RSpec.describe User, type: :model do
         expect(user.uid_required?).to be false
       end
     end
-
-    describe "#set_values" do
-      let(:omniauth_hash) do
-        {
-          "provider" => "line",
-          "uid" => "123456789",
-          "credentials" => {
-            "refresh_token" => "refresh_token_value",
-            "secret" => "secret_value"
-          },
-          "info" => {
-            "name" => "Test User"
-          }
-        }
-      end
-
-      it "providerとuidが一致する場合、値を設定すること" do
-        expect(oauth_user.set_values(omniauth_hash)).to be_truthy
-      end
-
-      it "providerが一致しない場合、早期returnすること" do
-        omniauth_hash["provider"] = "google"
-        expect(oauth_user.set_values(omniauth_hash)).to be_nil
-      end
-
-      it "uidが一致しない場合、早期returnすること" do
-        omniauth_hash["uid"] = "different_uid"
-        expect(oauth_user.set_values(omniauth_hash)).to be_nil
-      end
-    end
   end
 
   describe "classメソッド" do


### PR DESCRIPTION
<!-- github copilot レビューは日本語でお願いします -->
# 概要
<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->

line_omniauth周辺のリファクタリング

# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイントです -->

- app
  - controllers/users
    - M omniauth_callbacks_controller.rb 15, 12
      - lineログイン時、メールアドレスをuidではなく、nanoidで生成したランダムな値を用いて設定するように
      - rubocopを無効化していた記述を削除し、調整しました
      - #set_valuesを削除
  - models
    - M user.rb 0, 29
      - メソッド#social_profile, #set_values, #set_values_row_infoを削除
        - これらはLINEログイン実装時に実装したが、結局使用しなかったメソッド




<!-- github copilot レビューは日本語でお願いします -->

