### PR TITLE
Refact/gantt chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@
 /erd.pdf
 
 /.simplecov
+
+/pr_template.md

--- a/app/controllers/gantt_chart_controller.rb
+++ b/app/controllers/gantt_chart_controller.rb
@@ -3,27 +3,15 @@ class GanttChartController < ApplicationController
   before_action :authenticate_user!
 
   def show
-    @milestones = current_user.milestones.includes(:tasks).on_chart.not_completed.start_date_asc
+    milestones = current_user.milestones.includes(:tasks).on_chart.not_completed.start_date_asc
 
-    if @milestones.empty?
+    if milestones.empty?
       flash[:alert] = "チャートに表示する星座がひとつもありません"
       redirect_to user_path(current_user)
       return
     end
 
-    # 全てのマイルストーンの開始日と終了日から表示する日付範囲を決定
-    # 始まりはmilestones最小の日付より1日前
-    # 終わりはmilestones最大の日付より５日後
-    @date_range = date_range(@milestones)
-
-    # 各マイルストーンの幅と位置を計算
-    @chart_total_width = 0
-
-    # @milestonesから、各milestoneのidに紐づけてwidthサイズとleft座標を設定する
-    @milestone_widths, @milestone_lefts = milestone_widths_lefts_hash(@milestones)
-
-    # ガントチャート全体の幅を計算（最後のマイルストーンの右端 + 余白）
-    @chart_total_width = @milestone_lefts[@milestones.last.id].to_i + @milestone_widths[@milestones.last.id].to_i + 20
+    @chart_presenter = GanttChartPresenter.new(milestones)
   end
 
   def milestone_show

--- a/app/controllers/limited_sharing_milestones_controller.rb
+++ b/app/controllers/limited_sharing_milestones_controller.rb
@@ -8,7 +8,7 @@ class LimitedSharingMilestonesController < ApplicationController
     @title = "限定公開の星座"
 
     prepare_meta_tags(@milestone)
-    prepare_for_chart(@milestone) if @milestone.is_on_chart
+    @chart_presenter = GanttChartPresenter.new([@milestone]) if @milestone.on_chart?
     @milestone_tasks = @milestone.tasks
   end
 
@@ -85,13 +85,6 @@ class LimitedSharingMilestonesController < ApplicationController
       end_date: base_task.end_date,
       user: base_task.user
     )
-  end
-
-  def prepare_for_chart(milestone)
-    # milestone_chartの幅と位置情報を計算
-    @milestone_widths, @milestone_lefts = milestone_widths_lefts_hash([milestone])
-    @date_range = date_range([milestone])
-    @chart_total_width = @milestone_widths[milestone.id].to_i + 40
   end
 
   def prepare_meta_tags(milestone)

--- a/app/controllers/milestones_controller.rb
+++ b/app/controllers/milestones_controller.rb
@@ -33,7 +33,7 @@ class MilestonesController < ApplicationController
 
     if @milestone.is_public || current_user?(@milestone.user)
       prepare_meta_tags(@milestone)
-      prepare_for_chart(@milestone) if @milestone.is_on_chart
+      @chart_presenter = GanttChartPresenter.new([@milestone]) if @milestone.on_chart?
 
       @milestone_tasks = tasks_ransack_result
       @from_milestone_show = true
@@ -197,16 +197,6 @@ class MilestonesController < ApplicationController
 
     flash[:alert] = "アクセス権限がありません"
     redirect_to user_path(current_user)
-  end
-
-  def prepare_for_chart(milestone)
-    return if milestone.start_date.nil? || milestone.end_date.nil?
-    return unless milestone.on_chart?
-
-    # milestone_chartの幅と位置情報を計算
-    @milestone_widths, @milestone_lefts = milestone_widths_lefts_hash([milestone])
-    @date_range = date_range([milestone])
-    @chart_total_width = @milestone_widths[milestone.id].to_i + 40
   end
 
   def other_guest_milestone?(milestone)

--- a/app/controllers/task_milestone_assignments_controller.rb
+++ b/app/controllers/task_milestone_assignments_controller.rb
@@ -22,7 +22,7 @@ class TaskMilestoneAssignmentsController < ApplicationController
     end
 
     if success_flag
-      prepare_for_chart(@milestone) if @milestone.is_on_chart
+      @chart_presenter = GanttChartPresenter.new([@milestone]) if @milestone.on_chart?
       @milestone_tasks = tasks_ransack_result
 
       flash.now[:notice] = "星座のタスクを更新しました"
@@ -67,15 +67,5 @@ class TaskMilestoneAssignmentsController < ApplicationController
     @q = @milestone.tasks.ransack(params[:q])
     @q.sorts = ["start_date asc", "end_date asc"] if @q.sorts.empty?
     @q.result(distinct: true).includes(:user)
-  end
-
-  def prepare_for_chart(milestone)
-    return if milestone.start_date.nil? || milestone.end_date.nil?
-    return unless milestone.on_chart?
-
-    # milestone_chartの幅と位置情報を計算
-    @milestone_widths, @milestone_lefts = milestone_widths_lefts_hash([milestone])
-    @date_range = date_range([milestone])
-    @chart_total_width = @milestone_widths[milestone.id].to_i + 40
   end
 end

--- a/app/helpers/gantt_chart_helper.rb
+++ b/app/helpers/gantt_chart_helper.rb
@@ -1,10 +1,46 @@
 module GanttChartHelper
+  # 日付行の高さ（px）
+  DATE_ROW_HEIGHT = 40
+
+  # 星座のタイトルの表示文字数を決める際に使用する
+  CHARS_PER_TASK = 2
+  MILESTONE_TITLE_MIN_LENGTH = 10
+
+  # タスクチャートの設定
+  TASK_MARGIN_TOP = 8
+  TASK_TITLE_MAX_LENGTH = 15
+  HEIGHT_PER_CHARS = 15
+  TASK_MIN_COUNT = 3
+  WIDTH_PER_TASK = 80
+  # ↓この値で、星座の右端ボーダーにタスクが重ならないように調整
+  TASK_RIGHT_MARGIN_FROM_BORDER = 9.5 # ボーダーの幅の半分(1.5px) + タスクの幅(size-4)の半分(8px)
+
+  # 星座幅設定
+  MILESTONE_CLOSED_WIDTH = 45
+  MILESTONE_SPACING = 15
+  MILESTONE_INITIAL_POSITION = 15
+
+  # チャート最後に足す隙間
+  CHART_END_MARGIN = 20
+
+  # チャート全体の日付範囲設定
+  DISPLAY_START_MARGIN_DAYS = 1  # 含まれる星座の最速の開始日より何日前から表示
+  DISPLAY_END_MARGIN_DAYS = 5    # 含まれる星座の最遅の終了日より何日後まで表示
+
+  # ヘッダー高さ
+  MILESTONE_HEADER_HEIGHT = 35
+  MILESTONE_HEADER_SHIFT_UP = 30 # チャート部分ヘッダーを上にずらすための値
+
+  # 星座のマージン設定
+  MILESTONE_HEADER_WIDTH_MARGIN = 20
+  MILESTONE_HEADER_LEFT_MARGIN = 10
+
   def milestone_widths_lefts_hash(milestones)
-    current_position = 15
+    current_position = MILESTONE_INITIAL_POSITION
     milestone_widths = {}
     milestone_lefts = {}
 
-    # マイルストーンのタスク数を取得
+    # 星座のタスク数を取得
     if milestones.first.instance_of?(Milestone)
       task_counts = Task.where(milestone_id: milestones.map(&:id)).group(:milestone_id).count
     elsif milestones.first.instance_of?(LimitedSharingMilestone)
@@ -17,16 +53,16 @@ module GanttChartHelper
     milestones.each do |milestone|
       task_counts[milestone.id] = 0 if task_counts[milestone.id].nil?
 
-      task_count = [task_counts[milestone.id], 3].max
+      task_count = [task_counts[milestone.id], TASK_MIN_COUNT].max
 
       width_size = width_size(task_count, milestone)
 
       # 幅と左位置を保存
-      milestone_widths[milestone.id] = width_size.to_s
-      milestone_lefts[milestone.id] = current_position.to_s
+      milestone_widths[milestone.id] = width_size
+      milestone_lefts[milestone.id] = current_position
 
       # 次の星座の位置を更新
-      current_position += width_size + 15
+      current_position += width_size + MILESTONE_SPACING
     end
 
     [milestone_widths, milestone_lefts]
@@ -36,14 +72,14 @@ module GanttChartHelper
     return if milestones.empty?
 
     all_dates = milestones.flat_map { |milestone| [milestone.start_date, milestone.end_date] }
-    min_date = all_dates.min - 1.day
-    max_date = all_dates.max + 5.day
+    min_date = all_dates.min - DISPLAY_START_MARGIN_DAYS.days
+    max_date = all_dates.max + DISPLAY_END_MARGIN_DAYS.days
 
     [min_date, max_date]
   end
 
   def date_range(milestones)
-    # 全てのマイルストーンの開始日と終了日から表示する日付範囲を決定
+    # 全ての星座の開始日と終了日から表示する日付範囲を決定
     # min_dateは最小の日付より1日前
     # max_dateは最大の日付より５日後
     min_date, max_date = min_max_date(milestones)
@@ -68,14 +104,14 @@ module GanttChartHelper
   def width_size(task_count, milestone)
     # タスク数に応じて幅を設定
     if milestone.open?
-      80 * task_count
+      WIDTH_PER_TASK * task_count
     else
-      45
+      MILESTONE_CLOSED_WIDTH
     end
   end
 
   def milestone_title_truncate_num(milestone)
-    [milestone.tasks.count * 2, 10].max
+    [milestone.tasks.count * CHARS_PER_TASK, MILESTONE_TITLE_MIN_LENGTH].max
   end
 
   def date_class(date)

--- a/app/presenters/gantt_chart_presenter.rb
+++ b/app/presenters/gantt_chart_presenter.rb
@@ -1,0 +1,35 @@
+class GanttChartPresenter
+  include GanttChartHelper
+
+  attr_reader :milestones
+
+  def initialize(milestones)
+    @milestones = milestones
+  end
+
+  def chart_data
+    {
+      date_range: date_range(@milestones), # チャートの日付範囲
+      milestone_widths: milestone_widths, # 星座ごとの幅
+      milestone_lefts: milestone_lefts, # 星座ごとの左位置
+      chart_total_width: chart_total_width, # チャート全体の幅
+      milestones: @milestones # chart_presenter.milestonesでも参照できるが、chart_dataでまとめて取得することで統一した記述にしている
+    }
+  end
+
+  private
+
+  def milestone_widths
+    milestone_widths_lefts_hash(@milestones)[0] # メソッドの戻り値は[widths, lefts]の配列
+  end
+
+  def milestone_lefts
+    milestone_widths_lefts_hash(@milestones)[1] # メソッドの戻り値は[widths, lefts]の配列
+  end
+
+  def chart_total_width
+    last_milestone_left = milestone_lefts[@milestones.last.id]
+    last_milestone_width = milestone_widths[@milestones.last.id]
+    last_milestone_left + last_milestone_width + CHART_END_MARGIN
+  end
+end

--- a/app/presenters/milestone_chart_presenter.rb
+++ b/app/presenters/milestone_chart_presenter.rb
@@ -1,0 +1,64 @@
+class MilestoneChartPresenter
+  include ::GanttChartHelper
+
+  def initialize(milestone, date_range, milestone_widths, milestone_lefts)
+    @milestone = milestone
+    @date_range = date_range
+    @milestone_widths = milestone_widths
+    @milestone_lefts = milestone_lefts
+  end
+
+  def milestone_data
+    {
+      start_index: start_index,
+      end_index: end_index,
+      height: milestone_height,
+      top: milestone_top,
+      width: milestone_width,
+      left: milestone_left,
+      color: @milestone.color,
+      truncate_num: milestone_title_truncate_num,
+      tasks: tasks
+    }
+  end
+
+  private
+
+  def tasks
+    base_tasks = @milestone.tasks.valid_dates_nil
+
+    not_completed_tasks = base_tasks.not_completed.start_date_asc
+    completed_tasks = base_tasks.completed.start_date_asc
+
+    not_completed_tasks + completed_tasks
+  end
+
+  def start_index
+    @date_range.index { |d| d.to_date == @milestone.start_date.to_date }
+  end
+
+  def end_index
+    @date_range.index { |d| d.to_date == @milestone.end_date.to_date }
+  end
+
+  def milestone_height
+    (end_index - start_index + 1) * DATE_ROW_HEIGHT
+  end
+
+  def milestone_top
+    start_index * DATE_ROW_HEIGHT
+  end
+
+  def milestone_width
+    @milestone_widths[@milestone.id]
+  end
+
+  def milestone_left
+    @milestone_lefts[@milestone.id]
+  end
+
+  # タスク数に応じて幅が変わるため、それに応じてタイトルの文字数を決定
+  def milestone_title_truncate_num
+    [@milestone.tasks.count * CHARS_PER_TASK, MILESTONE_TITLE_MIN_LENGTH].max
+  end
+end

--- a/app/presenters/task_chart_presenter.rb
+++ b/app/presenters/task_chart_presenter.rb
@@ -1,0 +1,72 @@
+class TaskChartPresenter
+  include GanttChartHelper
+
+  def initialize(task, tasks)
+    @task = task
+    @tasks = tasks
+  end
+
+  def task_data
+    {
+      height: task_height,
+      top: task_top,
+      left: task_left,
+      title_height: task_title_height,
+      margin_top: TASK_MARGIN_TOP,
+      color: @task.milestone.color,
+      task_index: task_index,
+      task_count: task_count
+    }
+  end
+
+  private
+
+  def task_height
+    if @task.start_date && @task.end_date
+      (task_end_index - task_start_index + 1) * DATE_ROW_HEIGHT
+    else
+      DATE_ROW_HEIGHT
+    end
+  end
+
+  def task_top
+    if @task.start_date && @task.end_date
+      task_start_index * DATE_ROW_HEIGHT
+    elsif @task.start_date && !@task.end_date
+      task_start_index * DATE_ROW_HEIGHT
+    elsif !@task.start_date && @task.end_date
+      task_end_index * DATE_ROW_HEIGHT
+    else
+      0 # 両方無い場合はここに来ることはないはず
+    end
+  end
+
+  def milestone_width_size
+    task_count * WIDTH_PER_TASK
+  end
+
+  def task_left
+    section_ratio = 1.000 / (@tasks.count + 1)
+    ((milestone_width_size * section_ratio * (task_index + 1)) - TASK_RIGHT_MARGIN_FROM_BORDER).to_i
+  end
+
+  def task_title_height
+    ([@task.title.length, TASK_TITLE_MAX_LENGTH].min + 1) * HEIGHT_PER_CHARS
+  end
+
+  def task_index
+    @tasks.index(@task)
+  end
+
+  def task_count
+    [@tasks.count, TASK_MIN_COUNT].max
+  end
+
+  def task_start_index
+    (@task.start_date - @task.milestone.start_date).to_i
+  end
+
+  def task_end_index
+    (@task.end_date - @task.milestone.start_date).to_i
+  end
+end

--- a/app/views/gantt_chart/_chart.html.erb
+++ b/app/views/gantt_chart/_chart.html.erb
@@ -1,56 +1,47 @@
 <%
-            start_index = @date_range.index { |d| d.to_date == milestone.start_date.to_date }
-            end_index = @date_range.index { |d| d.to_date == milestone.end_date.to_date }
-            milestone_height = (end_index - start_index + 1) * 40
-            milestone_top = start_index * 40
+            constants = {
+              header_height: GanttChartHelper::MILESTONE_HEADER_HEIGHT,
+              header_shift_up: GanttChartHelper::MILESTONE_HEADER_SHIFT_UP,
+              width_margin: GanttChartHelper::MILESTONE_HEADER_WIDTH_MARGIN,
+              left_margin: GanttChartHelper::MILESTONE_HEADER_LEFT_MARGIN
+            }
 
-            # milestoneチャートの幅と位置
-            milestone_width = @milestone_widths[milestone.id]
-            milestone_left = @milestone_lefts[milestone.id]
-
-            # 色の設定(taskもこの色を使う)
-            milestone_color = milestone.color
-            truncate_num = milestone_title_truncate_num(milestone)
+            # MilestoneChartPresenterを使って、milestoneのデータを取得
+            chart_data =  chart_presenter.chart_data
+            milestone_presenter = MilestoneChartPresenter.new(milestone, chart_data[:date_range], chart_data[:milestone_widths], chart_data[:milestone_lefts])
+            milestone_data = milestone_presenter.milestone_data
           %>
 
           <!-- milestone名前 -->
           <div class="absolute border-3 rounded-md flex flex-col items-center z-30"
-            style="top: <%= milestone_top - 30 %>px;
-            height: 35px;
-            width: <%= milestone_width.to_i - 20 %>px;
-            left: <%= milestone_left.to_i + 10 %>px;
-            background-color: <%= milestone_color %>cc;
-            border-color: <%= milestone_color %>cc;
+            style="top: <%= milestone_data[:top] - constants[:header_shift_up] %>px;
+            height: <%= constants[:header_height] %>px;
+            width: <%= milestone_data[:width] - constants[:width_margin] %>px;
+            left: <%= milestone_data[:left] + constants[:left_margin] %>px;
+            background-color: <%= milestone_data[:color] %>cc;
+            border-color: <%= milestone_data[:color] %>cc;
             ">
 
             <% if milestone.open? %>
-              <%= milestone.title.truncate(truncate_num, omission: '...') %>
+              <%= milestone.title.truncate(milestone_data[:truncate_num], omission: '...') %>
             <% end %>
           </div>
 
           <!-- milestone本体、内部にtask -->
           <div class="absolute border-3 rounded-md"
-            style="top: <%= milestone_top %>px; 
-            height: <%= milestone_height %>px; 
-            width: <%= milestone_width %>px; 
-            left: <%= milestone_left.to_i %>px;
-            background-color: <%= milestone_color %>50;
-            border-color: <%= milestone_color %>cc;
+            style="top: <%= milestone_data[:top] %>px; 
+            height: <%= milestone_data[:height] %>px; 
+            width: <%= milestone_data[:width] %>px; 
+            left: <%= milestone_data[:left] %>px;
+            background-color: <%= milestone_data[:color] %>50;
+            border-color: <%= milestone_data[:color] %>cc;
             ">
 
             <% if milestone.open? %>
-              <% 
-                # タスクの取得
-                base_tasks = milestone.tasks.valid_dates_nil
-                not_completed_tasks = base_tasks.not_completed.start_date_asc
-                completed_tasks = base_tasks.completed.start_date_asc
-                tasks = not_completed_tasks + completed_tasks
-              %>
-
               <!-- Task（丸と線） -->
               <div id="chart_<%=milestone.id%>">
-                <% tasks.each do |task| %>
-                  <%= render "gantt_chart/task_chart", task: task, tasks: tasks %>
+                <% milestone_data[:tasks].each do |task| %>
+                  <%= render "gantt_chart/task_chart", task: task, tasks: milestone_data[:tasks] %>
                 <% end %>
               </div>
 
@@ -62,7 +53,7 @@
                 </span>
                 <div class="flex w-full justify-start items-center [writing-mode:vertical-rl]">
                   <div>
-                  <%= milestone.title.truncate(truncate_num, omission: '...') %>
+                  <%= milestone.title.truncate(milestone_data[:truncate_num], omission: '...') %>
                   </div>
                 </div>
               <% end %>

--- a/app/views/gantt_chart/_chart_layout.html.erb
+++ b/app/views/gantt_chart/_chart_layout.html.erb
@@ -1,5 +1,7 @@
+<% chart_data = chart_presenter.chart_data %>
+
   <div id="gantt_chart" class="h-[90vh] overflow-auto border rounded-lg shadow-sm border-base-300 bg-base-300/50">
-    <div class="flex min-w-full" style="width: max(<%= chart_total_width %>px, 100%);">
+    <div class="flex min-w-full" style="width: max(<%= chart_data[:chart_total_width] %>px, 100%);">
 
       <!-- 日付列 -->
       <div class="sticky left-0 w-[60px] border-r border-gray-700 bg-gray-800 relative z-60">
@@ -9,7 +11,7 @@
           日付
         </div>
         <div class="flex flex-col z-60">
-          <% date_range.each_with_index do |date, index| %>
+          <% chart_data[:date_range].each_with_index do |date, index| %>
 
             <%# 日付表示部の色を決める %>
             <% date_color = date_header_color(date) %>
@@ -25,7 +27,7 @@
       <div class="flex-grow relative">
         <!-- ヘッダー行 - 星座名 (固定) -->
         <div class="sticky top-0 h-14 flex z-50 w-full">
-          <% milestones.each do |milestone| %>
+          <% chart_data[:milestones].each do |milestone| %>
             <%
               # 色の設定
               milestone_color = milestone.color
@@ -33,8 +35,8 @@
             %>
           <div class="border border-3 rounded-md text-base-200 text-xl absolute flex items-center justify-start font-medium px-2 text-center"
               style="
-              width: <%= milestone_widths[milestone.id] %>px;
-              left: <%= milestone_lefts[milestone.id].to_i %>px;
+              width: <%= chart_data[:milestone_widths][milestone.id] %>px;
+              left: <%= chart_data[:milestone_lefts][milestone.id] %>px;
               top: 0; height: 100%;
               background-color: <%= milestone_color %>b3;
               border-color: <%= milestone_color %>cc;
@@ -77,28 +79,27 @@
         <div class="relative">
           <!-- 日付ごとの行 -->
           <div>
-          <% date_range.each_with_index do |date, index| %>
+            <% chart_data[:date_range].each_with_index do |date, index| %>
+              <%# 日付線の色を決める %>
+              <% date_color = date_line_color(date) %>
 
-            <%# 日付線の色を決める %>
-            <% date_color = date_line_color(date) %>
-
-            <div
-              class="h-[40px] border-b border-base-100 z-30
-              <%= (index == 0) ? 'border-t' : '' %>
-              <%= (date.mday == 1) ? 'border-t-3 border-t-info' : '' %> <%= date_color %>
-              "
-              style="width: max(<%= chart_total_width %>px, 100%);"
-            >
-            <%# @chart_total_width：日付の横線のサイズを指定している %>
-            <%# 100%にすると、画面幅以上のチャートになった際に日付線が画面幅で切れてしまう %>
-            <%# この行には何も表示しない（背景色のみ） %>
-            </div>
-          <% end %>
+              <div
+                class="h-[40px] border-b border-base-100 z-30
+                <%= (index == 0) ? 'border-t' : '' %>
+                <%= (date.mday == 1) ? 'border-t-3 border-t-info' : '' %> <%= date_color %>
+                "
+                style="width: max(<%= chart_data[:chart_total_width] %>px, 100%);"
+              >
+              <%# chart_total_width：日付の横線のサイズを指定している %>
+              <%# 100%にすると、画面幅以上のチャートになった際に日付線が画面幅で切れてしまう %>
+              <%# この行には何も表示しない（背景色のみ） %>
+              </div>
+            <% end %>
           </div>
 
           <!-- milestone（長方形） -->
-        <% milestones.each do |milestone| %>
-          <%= render "gantt_chart/chart", milestone: milestone, milestone_widths: milestone_widths, milestone_lefts: milestone_lefts, date_range: date_range %>
+        <% chart_data[:milestones].each do |milestone| %>
+          <%= render "gantt_chart/chart", milestone: milestone, chart_presenter: chart_presenter %>
         <% end %>
       </div>
     </div>

--- a/app/views/gantt_chart/_task_chart.html.erb
+++ b/app/views/gantt_chart/_task_chart.html.erb
@@ -1,39 +1,12 @@
 <%
-      # 色の設定(taskもこの色を使う)
-      milestone = task.milestone
-      milestone_color = milestone.color
-      task_index = tasks.index(task)
-      task_count = [tasks.count, 3].max
-      milestone_width_size = (task_count * 80)
-          %>
+          # 定数をまとめて変数に代入
+          constants = {
+            task_title_max_length: GanttChartHelper::TASK_TITLE_MAX_LENGTH,
+          }
 
-          <%
-              if task.start_date && task.end_date
-                # task_xxx_index：taskの表示はmilestoneの四角の上辺を始点に始まっているため、taskのmilestone.start_dateを引く
-                task_start_index = (task.start_date - task.milestone.start_date).to_i
-                task_end_index = (task.end_date - task.milestone.start_date).to_i
-
-                task_height = (task_end_index - task_start_index + 1) * 40
-                task_top = task_start_index * 40
-              elsif task.start_date && !task.end_date
-                task_start_index = (task.start_date - task.milestone.start_date).to_i
-                task_height = 40
-                task_top = task_start_index * 40
-              elsif !task.start_date && task.end_date
-                task_end_index = (task.end_date - task.milestone.start_date).to_i
-                task_height = 40
-                task_top = task_end_index * 40
-              else
-              end
-          margin_top = 8
-          task_title_height = ([task.title.length, 14].min + 1) * 15
-
-          # taskの水平位置を計算
-          # section_widthでtask一つあたりの占有割合を出す
-          # task_leftで現在のtaskがこのmilestoneの何%の位置かで計算し、task要素の幅分右にずれているので、左にずらす
-          # 9.5はボーダーの幅の半分の1.5とtaskの幅の半分の8を足したもの
-          section_width = 1.000 / (tasks.count + 1)
-          task_left = "#{milestone_width_size * section_width * (task_index + 1) - 9.5}"
+          # TaskChartPresenterを使って、taskのデータを取得
+          presenter = TaskChartPresenter.new(task, tasks)
+          task_data = presenter.task_data
         %>
 
         <%# heightの-5は上下につける〇の要素のサイズ分 %>
@@ -41,26 +14,26 @@
           id="task_chart_<%= task.id %>"
           class="absolute flex flex-col items-center cursor-pointer"
           onclick="tasks_show_modal_<%=task.id%>_target.showModal()"
-          style="top: <%= task_top + margin_top %>px;
-          height: <%= task_height - (margin_top * 2) - 5 %>px;
-          left: <%= task_left %>px"
+          style="top: <%= task_data[:top] + task_data[:margin_top] %>px;
+          height: <%= task_data[:height] - (task_data[:margin_top] * 2) - 5 %>px;
+          left: <%= task_data[:left] %>px"
           >
           <!-- タスク名 -->
           <div class="absolute left-8 top-2 text-start [writing-mode:vertical-rl] ">
             <div class="absolute left-[-14px] w-4 h-4 bg-base-200" style="clip-path: polygon(100% 0, 0 0, 100% 100%);"></div>
-            <div style="height: <%= task_title_height %>px">
-              <%= task.title.truncate(15, omission: '...') %>
+            <div style="height: <%= task_data[:title_height] %>px">
+              <%= task.title.truncate(constants[:task_title_max_length], omission: "...") %>
             </div>
           </div>
 
           <!-- 開始点の円 -->
-          <div class="z-40 <%= task.in_progress? ? "size-4 relative top-1 mask mask-triangle-2" : "size-4 rounded-full" %>" style="background-color: <%= task.completed? ? "#{milestone_color}4d" : milestone_color %>;"></div>
+          <div class="z-40 <%= task.in_progress? ? "size-4 relative top-1 mask mask-triangle-2" : "size-4 rounded-full" %>" style="background-color: <%= task.completed? ? "#{task_data[:color]}4d" : task_data[:color] %>;"></div>
 
           <% if task.start_date && task.end_date %>
             <!-- 線 -->
-            <div class="w-1 flex-grow z-40" style="background-color: <%= task.completed? ? "#{milestone_color}4d" : milestone_color %>;"></div>
+            <div class="w-1 flex-grow z-40" style="background-color: <%= task.completed? ? "#{task_data[:color]}4d" : task_data[:color] %>;"></div>
 
             <!-- 終了点の円 -->
-            <div class="z-40 <%= task.in_progress? ? "size-4 relative -top-1 mask mask-triangle" : "size-4 rounded-full" %>" style="background-color: <%= task.completed? ? "#{milestone_color}4d" : milestone_color %>;"></div>
+            <div class="z-40 <%= task.in_progress? ? "size-4 relative -top-1 mask mask-triangle" : "size-4 rounded-full" %>" style="background-color: <%= task.completed? ? "#{task_data[:color]}4d" : task_data[:color] %>;"></div>
           <% end %>
         </button>

--- a/app/views/gantt_chart/show.html.erb
+++ b/app/views/gantt_chart/show.html.erb
@@ -1,11 +1,6 @@
 <div class="container mx-auto p-4">
   <%= render "flash" %>
-  <%= render "chart_layout", 
-             date_range: @date_range, 
-             milestones: @milestones, 
-             milestone_widths: @milestone_widths, 
-             milestone_lefts: @milestone_lefts, 
-             chart_total_width: @chart_total_width %>
+  <%= render "chart_layout", chart_presenter: @chart_presenter %>
 </div>
 
 
@@ -16,7 +11,7 @@
 <%= turbo_frame_tag "milestone_show_modal" %>
 <%= turbo_frame_tag "tasks_copy_modal" %>
 
-<% @milestones.each do |milestone| %>
+<% @chart_presenter.milestones.each do |milestone| %>
   <% milestone.tasks.includes(:user).each do |task| %>
     <%= render "tasks/tasks_show_modal", task: task, tasks_show_modal_open: false %>
   <% end %>

--- a/app/views/limited_sharing_milestones/show.html.erb
+++ b/app/views/limited_sharing_milestones/show.html.erb
@@ -160,12 +160,7 @@
             </div>
 
             <div class="overflow-x-auto text-sm">
-              <%= render "gantt_chart/chart_layout", 
-                date_range: @date_range, 
-                milestones: [@milestone], 
-                milestone_widths: @milestone_widths, 
-                milestone_lefts: @milestone_lefts, 
-                chart_total_width: @chart_total_width %>
+              <%= render "gantt_chart/chart_layout", chart_presenter: @chart_presenter %>
           </div>
           </div>
         <% end %>

--- a/app/views/milestones/show.html.erb
+++ b/app/views/milestones/show.html.erb
@@ -331,12 +331,7 @@
             </div>
 
             <div class="overflow-x-auto text-sm">
-              <%= render "gantt_chart/chart_layout", 
-                date_range: @date_range, 
-                milestones: [@milestone], 
-                milestone_widths: @milestone_widths, 
-                milestone_lefts: @milestone_lefts, 
-                chart_total_width: @chart_total_width %>
+              <%= render "gantt_chart/chart_layout", chart_presenter: @chart_presenter %>
             </div>
           </div>
         <% end %>

--- a/app/views/task_milestone_assignments/update.turbo_stream.erb
+++ b/app/views/task_milestone_assignments/update.turbo_stream.erb
@@ -37,12 +37,7 @@
 
   <% if @milestone.on_chart? %>
     <%= turbo_stream.replace "gantt_chart" do %>
-      <%= render "gantt_chart/chart_layout", 
-        date_range: @date_range, 
-        milestones: [@milestone], 
-        milestone_widths: @milestone_widths, 
-        milestone_lefts: @milestone_lefts, 
-        chart_total_width: @chart_total_width %>
+      <%= render "gantt_chart/chart_layout", chart_presenter: @chart_presenter %>
     <% end %>
   <% end %>
 <% end %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,7 +3,7 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   config.hosts << 'hoshi-ni-task-wo.net'
   config.hosts << 'hoshi-ni-task-wo.onrender.com'
-  config.hosts << 'hoshi-ni-task-wo-pr-249.onrender.com'
+  config.hosts << 'hoshi-ni-task-wo-pr-255.onrender.com'
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.


### PR DESCRIPTION
<!-- github copilot レビューは日本語でお願いします -->
# 概要
ガントチャート機能をPresenterパターンにリファクタリングし、コードの保守性と可読性を向上させました。
複雑なビジネスロジックをコントローラーからPresenterクラスに移行し、マジックナンバーを定数化することで、より保守しやすいコード構造を実現しました。

# 背景
- ガントチャート表示に関する複雑なロジックがコントローラーとビューに散在していた
- マジックナンバーが多数存在し、コードの可読性が低下していた
- 類似の処理が複数のコントローラーに重複していた


# 詳細な変更内容

## 追加されたファイル

### app/presenters/gantt_chart_presenter.rb
- チャート全体のデータ管理を担当する新しいPresenterクラス
- `chart_data`メソッドで日付範囲、星座の幅・位置、チャート全体幅、星座データを統一的に提供
- コントローラーから複雑な計算ロジックを分離

### app/presenters/milestone_chart_presenter.rb  
- 星座チャートの描画情報を管理するPresenterクラス
- 星座の開始・終了インデックス、高さ、位置、色などの描画データを計算
- タスクの取得と並び替えロジックを含む

### app/presenters/task_chart_presenter.rb
- タスクチャートの描画情報を管理するPresenterクラス
- タスクの高さ、位置、タイトル高さなどの描画データを計算
- タスクの水平位置とインデックス管理を担当

## 変更されたファイル

### app/controllers/gantt_chart_controller.rb
- 複雑な日付範囲計算、星座の幅・位置計算をPresenterに移行
- `GanttChartPresenter`のインスタンスを作成してビューに渡すシンプルな構造に変更
- コード行数を大幅に削減（15行削除、3行追加）

### app/controllers/limited_sharing_milestones_controller.rb
- `prepare_for_chart`メソッドを削除
- `GanttChartPresenter`を使用するよう変更
- チャート関連の重複コードを排除

### app/controllers/milestones_controller.rb
- `prepare_for_chart`メソッドを削除（11行削除）
- `GanttChartPresenter`を使用するよう統一
- コントローラーからビジネスロジックを分離

### app/controllers/task_milestone_assignments_controller.rb
- `prepare_for_chart`メソッドを削除（11行削除）
- `GanttChartPresenter`パターンに対応
- チャート更新処理を統一

### app/helpers/gantt_chart_helper.rb
- マジックナンバーを定数として定義（48行追加）
- `DATE_ROW_HEIGHT`、`TASK_MARGIN_TOP`、`WIDTH_PER_TASK`など計算で使用される値を定数化
- `milestone_widths_lefts_hash`メソッドの戻り値を文字列から数値に変更
- コードの可読性と保守性を大幅に向上

### app/views/gantt_chart/_chart.html.erb
- `MilestoneChartPresenter`を使用して星座データを取得
- 直接的な計算処理をPresenterに移行
- より宣言的で読みやすいコードに変更

### app/views/gantt_chart/_chart_layout.html.erb
- `chart_presenter.chart_data`から統一的にデータを取得
- 複数の変数受け渡しから単一のPresenterオブジェクトに変更
- ビューロジックを簡素化

### app/views/gantt_chart/_task_chart.html.erb
- `TaskChartPresenter`を使用してタスク描画データを取得
- 複雑な計算処理をPresenterに移行（42行削除、15行追加）
- よりクリーンで保守しやすいテンプレートに変更

### app/views/gantt_chart/show.html.erb
- Presenterオブジェクトを使用するようパラメータを簡素化
- 複数のインスタンス変数から`chart_presenter`の単一オブジェクトに変更

### app/views/limited_sharing_milestones/show.html.erb
- `chart_presenter`オブジェクトを使用するよう変更
- 複数パラメータの受け渡しを単純化

### app/views/milestones/show.html.erb
- `chart_presenter`オブジェクトを使用するよう変更
- ビューの統一性を確保

### app/views/task_milestone_assignments/update.turbo_stream.erb
- Turbo Streamでの更新処理も`chart_presenter`パターンに対応
- 統一されたデータアクセス方法を適用

<!-- github copilot レビューは日本語でお願いします -->
