### PR TITLE
Feature/completed tasks hide

### DIFF
--- a/app/controllers/gantt_chart_controller.rb
+++ b/app/controllers/gantt_chart_controller.rb
@@ -11,7 +11,7 @@ class GanttChartController < ApplicationController
       return
     end
 
-    @chart_presenter = GanttChartPresenter.new(milestones)
+    @chart_presenter = GanttChartPresenter.new(milestones, current_user)
   end
 
   def milestone_show

--- a/app/controllers/tasks/update_progress_controller.rb
+++ b/app/controllers/tasks/update_progress_controller.rb
@@ -1,0 +1,94 @@
+module Tasks
+  class UpdateProgressController < ApplicationController
+    before_action :set_task, only: [:update]
+    before_action :authenticate_user!
+    before_action :ensure_correct_user, only: [:update]
+    before_action :set_task_milestone, only: [:update]
+
+    # タスクの進捗状況を更新
+    # 完了した星座に関連付けられている場合は更新できない
+    def update
+      if @task.milestone_completed?
+        flash.now.alert = "このタスクは完成した星座に関連付けられています"
+        redirect_back fallback_location: tasks_path and return
+      end
+
+      @task.progress = @task.next_progress
+
+      if @task.save
+        update_task_milestone_and_load_tasks
+        flash.now.notice = "タスクの進捗状況を更新しました"
+      else
+        flash.now.alert = "タスクの進捗状況の更新に失敗しました"
+      end
+    end
+
+    private
+
+    def set_task
+      @task = Task.find(params[:id])
+    end
+
+    def set_task_milestone
+      @task_milestone = @task.milestone if @task.milestone.present?
+    end
+
+    def ensure_correct_user
+      task = Task.find(params[:id])
+
+      return if task.user.id == current_user.id
+
+      flash[:alert] = "アクセス権限がありません"
+      redirect_to user_path(current_user)
+    end
+
+    def update_task_milestone_and_load_tasks
+      return unless @task_milestone.present?
+
+      # 星座の進捗をタスクの進捗に合わせて更新
+      @task_milestone.update_progress
+
+      set_chart_tasks
+    end
+
+    def sort_tasks_by_complete_and_start_date(tasks)
+      # 完了したタスクを後ろにして、それぞれ開始日でソート
+      not_completed_tasks = tasks.not_completed.start_date_asc
+      completed_tasks = tasks.completed.start_date_asc
+      not_completed_tasks + completed_tasks
+    end
+
+    def set_chart_tasks
+      return unless @task_milestone.on_chart?
+
+      tasks = fetch_chart_tasks
+      @chart_tasks = sort_tasks_by_complete_and_start_date(tasks).to_a
+
+      # いま処理しているタスクがまだdbに存在していればチャートに表示するために追加
+      current_task = @task_milestone.tasks.find_by(id: @task.id)
+      @chart_tasks << current_task if current_task && @chart_tasks.exclude?(current_task)
+    end
+
+    def fetch_chart_tasks
+      # アクセス元のページを判定してタスクを取得
+      # チャート画面からのアクセスの場合：完了タスクを非表示にする設定を確認する
+      # 星座詳細画面からのアクセスの場合：常にすべてのタスクを表示
+      return @task_milestone.tasks.valid_dates_nil unless from_chart_page?
+
+      if current_user.completed_tasks_hidden?
+        @task_milestone.tasks.not_completed.valid_dates_nil
+      else
+        @task_milestone.tasks.valid_dates_nil
+      end
+    end
+
+    def from_chart_page?
+      # URLからアクセス元のページを判定
+      referer = request.referer
+      return false if referer.blank?
+
+      # チャート画面のURLパターンをチェック
+      referer.include?("/gantt_chart")
+    end
+  end
+end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -80,21 +80,6 @@ class TasksController < ApplicationController
   # #################################
   # CRUD以外のアクション
   # ###########################################
-  def update_progress
-    if @task.milestone_completed?
-      flash.now.alert = "このタスクは完成した星座に関連付けられています"
-      redirect_back fallback_location: tasks_path and return
-    end
-
-    @task.progress = @task.next_progress
-
-    if @task.save
-      update_task_milestone_and_load_tasks
-      flash.now.notice = "タスクの進捗状況を更新しました"
-    else
-      flash.now.alert = "タスクの進捗状況の更新に失敗しました"
-    end
-  end
 
   # タスクのautocomplete機能, stimulus_autocompleteで使用
   def autocomplete

--- a/app/helpers/gantt_chart_helper.rb
+++ b/app/helpers/gantt_chart_helper.rb
@@ -35,14 +35,18 @@ module GanttChartHelper
   MILESTONE_HEADER_WIDTH_MARGIN = 20
   MILESTONE_HEADER_LEFT_MARGIN = 10
 
-  def milestone_widths_lefts_hash(milestones)
+  def milestone_widths_lefts_hash(milestones, user = nil)
     current_position = MILESTONE_INITIAL_POSITION
     milestone_widths = {}
     milestone_lefts = {}
 
     # 星座のタスク数を取得
     if milestones.first.instance_of?(Milestone)
-      task_counts = Task.where(milestone_id: milestones.map(&:id)).group(:milestone_id).count
+      task_counts = if user&.completed_tasks_hidden?
+                      Task.where(milestone_id: milestones.map(&:id)).not_completed.group(:milestone_id).count
+                    else
+                      Task.where(milestone_id: milestones.map(&:id)).group(:milestone_id).count
+                    end
     elsif milestones.first.instance_of?(LimitedSharingMilestone)
       # 渡されたmilestonesがLimitedSharingMilestoneの場合
       # rubocop:disable Layout/LineLength

--- a/app/helpers/gantt_chart_helper.rb
+++ b/app/helpers/gantt_chart_helper.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ModuleLength
 module GanttChartHelper
   # 日付行の高さ（px）
   DATE_ROW_HEIGHT = 40
@@ -41,18 +42,7 @@ module GanttChartHelper
     milestone_lefts = {}
 
     # 星座のタスク数を取得
-    if milestones.first.instance_of?(Milestone)
-      task_counts = if user&.completed_tasks_hidden?
-                      Task.where(milestone_id: milestones.map(&:id)).not_completed.group(:milestone_id).count
-                    else
-                      Task.where(milestone_id: milestones.map(&:id)).group(:milestone_id).count
-                    end
-    elsif milestones.first.instance_of?(LimitedSharingMilestone)
-      # 渡されたmilestonesがLimitedSharingMilestoneの場合
-      # rubocop:disable Layout/LineLength
-      task_counts = LimitedSharingTask.where(limited_sharing_milestone_id: milestones.map(&:id)).group(:limited_sharing_milestone_id).count
-      # rubocop:enable Layout/LineLength
-    end
+    task_counts = milestone_task_counts_hash(milestones, user)
 
     milestones.each do |milestone|
       task_counts[milestone.id] = 0 if task_counts[milestone.id].nil?
@@ -149,4 +139,27 @@ module GanttChartHelper
       ""
     end
   end
+
+  def milestone_task_counts(milestones, user = nil)
+    if user&.completed_tasks_hidden?
+      Task.where(milestone_id: milestones.map(&:id)).not_completed.group(:milestone_id).count
+    else
+      Task.where(milestone_id: milestones.map(&:id)).group(:milestone_id).count
+    end
+  end
+
+  def limited_sharing_milestone_task_counts(milestones)
+    # rubocop:disable Layout/LineLength
+    LimitedSharingTask.where(limited_sharing_milestone_id: milestones.map(&:id)).group(:limited_sharing_milestone_id).count
+    # rubocop:enable Layout/LineLength
+  end
+
+  def milestone_task_counts_hash(milestones, user = nil)
+    if milestones.first.instance_of?(Milestone)
+      milestone_task_counts(milestones, user)
+    elsif milestones.first.instance_of?(LimitedSharingMilestone)
+      limited_sharing_milestone_task_counts(milestones)
+    end
+  end
 end
+# rubocop:enable Metrics/ModuleLength

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,4 +45,8 @@ class User < ApplicationRecord
   def uid_required?
     provider.present?
   end
+
+  def completed_tasks_hidden?
+    is_hide_completed_tasks == true
+  end
 end

--- a/app/presenters/gantt_chart_presenter.rb
+++ b/app/presenters/gantt_chart_presenter.rb
@@ -3,8 +3,9 @@ class GanttChartPresenter
 
   attr_reader :milestones
 
-  def initialize(milestones)
+  def initialize(milestones, current_user = nil)
     @milestones = milestones
+    @current_user = current_user
   end
 
   def chart_data
@@ -13,18 +14,19 @@ class GanttChartPresenter
       milestone_widths: milestone_widths, # 星座ごとの幅
       milestone_lefts: milestone_lefts, # 星座ごとの左位置
       chart_total_width: chart_total_width, # チャート全体の幅
-      milestones: @milestones # chart_presenter.milestonesでも参照できるが、chart_dataでまとめて取得することで統一した記述にしている
+      milestones: @milestones, # chart_presenter.milestonesでも参照できるが、chart_dataでまとめて取得することで統一した記述にしている
+      current_user: @current_user # 現在のユーザー情報
     }
   end
 
   private
 
   def milestone_widths
-    milestone_widths_lefts_hash(@milestones)[0] # メソッドの戻り値は[widths, lefts]の配列
+    milestone_widths_lefts_hash(@milestones, @current_user)[0] # メソッドの戻り値は[widths, lefts]の配列
   end
 
   def milestone_lefts
-    milestone_widths_lefts_hash(@milestones)[1] # メソッドの戻り値は[widths, lefts]の配列
+    milestone_widths_lefts_hash(@milestones, @current_user)[1] # メソッドの戻り値は[widths, lefts]の配列
   end
 
   def chart_total_width

--- a/app/presenters/milestone_chart_presenter.rb
+++ b/app/presenters/milestone_chart_presenter.rb
@@ -1,11 +1,12 @@
 class MilestoneChartPresenter
   include ::GanttChartHelper
 
-  def initialize(milestone, date_range, milestone_widths, milestone_lefts)
+  def initialize(milestone, date_range, milestone_widths, milestone_lefts, current_user)
     @milestone = milestone
     @date_range = date_range
     @milestone_widths = milestone_widths
     @milestone_lefts = milestone_lefts
+    @current_user = current_user
   end
 
   def milestone_data
@@ -27,10 +28,16 @@ class MilestoneChartPresenter
   def tasks
     base_tasks = @milestone.tasks.valid_dates_nil
 
-    not_completed_tasks = base_tasks.not_completed.start_date_asc
-    completed_tasks = base_tasks.completed.start_date_asc
+    if @current_user&.completed_tasks_hidden?
+      tasks = base_tasks.not_completed.start_date_asc
+    else
+      not_completed_tasks = base_tasks.not_completed.start_date_asc
+      completed_tasks = base_tasks.completed.start_date_asc
 
-    not_completed_tasks + completed_tasks
+      tasks = not_completed_tasks + completed_tasks
+    end
+
+    tasks
   end
 
   def start_index

--- a/app/views/gantt_chart/_chart.html.erb
+++ b/app/views/gantt_chart/_chart.html.erb
@@ -8,7 +8,7 @@
 
             # MilestoneChartPresenterを使って、milestoneのデータを取得
             chart_data =  chart_presenter.chart_data
-            milestone_presenter = MilestoneChartPresenter.new(milestone, chart_data[:date_range], chart_data[:milestone_widths], chart_data[:milestone_lefts])
+            milestone_presenter = MilestoneChartPresenter.new(milestone, chart_data[:date_range], chart_data[:milestone_widths], chart_data[:milestone_lefts], chart_data[:current_user])
             milestone_data = milestone_presenter.milestone_data
           %>
 

--- a/app/views/tasks/_progress_button.html.erb
+++ b/app/views/tasks/_progress_button.html.erb
@@ -1,6 +1,6 @@
 <div id="progress_button_<%=task.id%>">
   <% if !(task.is_a?(LimitedSharingTask)) && current_user?(task.user) %>
-    <%= button_to update_progress_task_path(task), method: :patch, form: { data: { turbo: true } }, class: "btn btn-base-200 flex w-full h-auto aspect-square flex-col items-center justify-center rounded-xl" do %>
+    <%= button_to tasks_update_progress_path(task), method: :put, form: { data: { turbo: true } }, class: "btn btn-base-200 flex w-full h-auto aspect-square flex-col items-center justify-center rounded-xl" do %>
       <% if task.progress == "not_started" %>
         <div class="text-xs text-base-100 whitespace-nowrap">
           <%= render "tasks/not_started_icon", color: task.milestone&.color %>

--- a/app/views/tasks/create.turbo_stream.erb
+++ b/app/views/tasks/create.turbo_stream.erb
@@ -29,8 +29,8 @@
   <% if @task_milestone && @task_create_success == true && @task_milestone.on_chart? %>
     <%= turbo_stream.replace "chart_#{@task_milestone.id}" do %>
       <div id="chart_<%=@task_milestone.id%>">
-      <% @tasks.each do |task| %>
-        <%= render "gantt_chart/task_chart", task: task, tasks: @tasks %>
+      <% @chart_tasks.each do |task| %>
+        <%= render "gantt_chart/task_chart", task: task, tasks: @chart_tasks%>
       <% end %>
       </div>
     <% end %>

--- a/app/views/tasks/destroy.turbo_stream.erb
+++ b/app/views/tasks/destroy.turbo_stream.erb
@@ -9,8 +9,8 @@
   <% if @task_milestone && @task_milestone.on_chart? %>
     <%= turbo_stream.replace "chart_#{@task_milestone.id}" do %>
       <div id="chart_<%=@task_milestone.id%>">
-      <% @tasks.each do |task| %>
-        <%= render "gantt_chart/task_chart", task: task, tasks: @tasks %>
+      <% @chart_tasks.each do |task| %>
+        <%= render "gantt_chart/task_chart", task: task, tasks: @chart_tasks %>
       <% end %>
       </div>
     <% end %>

--- a/app/views/tasks/update.turbo_stream.erb
+++ b/app/views/tasks/update.turbo_stream.erb
@@ -32,8 +32,8 @@
   <% if @task_milestone && @tasks_update_success == true && @task_milestone.on_chart? %>
     <%= turbo_stream.replace "chart_#{@task_milestone.id}" do %>
       <div id="chart_<%=@task_milestone.id%>">
-      <% @tasks.each do |task| %>
-        <%= render "gantt_chart/task_chart", task: task, tasks: @tasks %>
+      <% @chart_tasks.each do |task| %>
+        <%= render "gantt_chart/task_chart", task: task, tasks: @chart_tasks %>
       <% end %>
       </div>
     <% end %>

--- a/app/views/tasks/update_progress.turbo_stream.erb
+++ b/app/views/tasks/update_progress.turbo_stream.erb
@@ -15,8 +15,8 @@
 <% if @task_milestone && @task_milestone.on_chart? %>
   <%= turbo_stream.replace "chart_#{@task_milestone.id}" do %>
     <div id="chart_<%=@task_milestone.id%>">
-    <% @tasks.each do |task| %>
-      <%= render "gantt_chart/task_chart", task: task, tasks: @tasks %>
+    <% @chart_tasks.each do |task| %>
+      <%= render "gantt_chart/task_chart", task: task, tasks: @chart_tasks %>
     <% end %>
     </div>
   <% end %>

--- a/app/views/tasks/update_progress/update.turbo_stream.erb
+++ b/app/views/tasks/update_progress/update.turbo_stream.erb
@@ -3,12 +3,12 @@
 <% end %>
 
 <%= turbo_stream.replace "progress_button_#{@task.id}" do %>
-  <%= render "progress_button", task: @task %>
+  <%= render "tasks/progress_button", task: @task %>
 <% end %>
 
 <%= turbo_stream.replace "task_show_progress_button_id_#{@task.id}" do %>
   <div id="task_show_progress_button_id_<%= @task.id %>" class="flex w-full items-center justify-center">
-  <%= render "progress_button", task: @task %>
+  <%= render "tasks/progress_button", task: @task %>
   </div>
 <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   end
   namespace :tasks do
     resources :copies, only: [:show, :create]
+    resources :update_progress, only: [:update]
   end
 
   resources :milestones do


### PR DESCRIPTION
<!-- github copilot レビューは日本語でお願いします -->
# 概要
<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->

完了済みタスクをチャートに表示しない機能を追加しました。
それにあたり、update_progressを別コントローラに切り出しました。

# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイントです -->

- app
  - controllers
    - tasks
      - update_progress_controller.rb 94, 0
        - 新規: TasksControllerのupdate_progressメソッドを独立したコントローラーに分離
        - RuboCopのクラス長警告対応とコードの責任分離を実現
    - gantt_chart_controller.rb 1, 1
      - ユーザー設定に基づく完了タスク非表示機能に対応
    - tasks_controller.rb -15, +2
      - update_progressメソッドを削除し、新しいコントローラーに移譲
  - helpers
    - gantt_chart_helper.rb +17, -9
      - タスク数取得ロジックを3つのメソッドに分割: milestone_task_counts, limited_sharing_milestone_task_counts, milestone_task_counts_hash
      - コードの可読性向上とRuboCopのモジュール長警告対応
  - models
    - user.rb +4, 0
      - completed_tasks_hidden?メソッド追加
      - is_hide_completed_tasksフラグの状態を判定するヘルパーメソッド
  - presenters
    - gantt_chart_presenter.rb 6, 4
      - 完了タスク非表示設定に対応したタスク取得ロジックの調整
    - milestone_chart_presenter.rb 11, 4
      - 同上、チャート表示でのタスクフィルタリング対応
  - views
    - gantt_chart
      - _chart.html.erb 1, 1
        - プレゼンター経由での表示ロジック調整に対応
    - tasks
      - update_progress
        - update.turbo_stream.erb 移動・パス修正
          - tasks/からtasks/update_progress/に移動し、update_progress.turbo_stream.erbから名称変更
      - _progress_button.html.erb 1, 1
        - update_progress_task_pathからtasks_update_progress_pathに変更
        - HTTPメソッドもpatchからputに変更
      - create.turbo_stream.erb 2, 2
        - パーシャルパスの修正: "progress_button"から"tasks/progress_button"に
      - destroy.turbo_stream.erb 2, 2
        - 同上
      - update.turbo_stream.erb 2, 2
        - 同上
  - config
    - routes.rb +1, 0
      - tasks名前空間内にupdate_progressリソースを追加
      - 新コントローラーへのルーティング設定


<!-- github copilot レビューは日本語でお願いします -->

