### PR TITLE
Fix/タスク作成・更新モーダルでの星座選択に関する2つのバグを修正しました

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -32,7 +32,7 @@ class TasksController < ApplicationController
     @milestones = if params[:milestone_id]
                     user.milestones.where(id: params[:milestone_id])
                   else
-                    user.milestones
+                    user.milestones.not_completed
                   end
 
     if @task.save
@@ -52,7 +52,7 @@ class TasksController < ApplicationController
   # turbo_stream更新している
   def update
     user = current_user
-    @milestones = user.milestones
+    @milestones = user.milestones.not_completed
 
     if @task.update(task_params)
       # タスクの更新に成功した場合、タスク詳細を表示

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -29,7 +29,8 @@ class TasksController < ApplicationController
     user = current_user
 
     # params[:milestone_id]が存在する場合（milestone_showからのアクセス）
-    @milestones = if params[:milestone_id]
+    @from_milestone_show = params[:milestone_id].present?
+    @milestones = if @from_milestone_show
                     user.milestones.where(id: params[:milestone_id])
                   else
                     user.milestones.not_completed

--- a/app/views/tasks/create.turbo_stream.erb
+++ b/app/views/tasks/create.turbo_stream.erb
@@ -8,7 +8,7 @@
 
   <% if @task_create_success %>
    <%= turbo_stream.replace "tasks_new_stream_target" do %>
-      <%= render "tasks_new_modal", task: Task.new, milestones: @milestones %>
+      <%= render "tasks_new_modal", task: Task.new, milestones: @milestones, from_milestone_show: @from_milestone_show %>
     <% end %>
 
     <%= turbo_stream.prepend "tasks_content" do %>
@@ -21,7 +21,7 @@
 
   <% else %>
     <%= turbo_stream.replace "tasks_new_stream_target" do %>
-      <%= render "tasks_new_modal", task: @task, milestones: @milestones, task_new_modal_open: @task_new_modal_open %>
+      <%= render "tasks_new_modal", task: @task, milestones: @milestones, from_milestone_show: @from_milestone_show, task_new_modal_open: @task_new_modal_open %>
     <% end %>
   <% end %>
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,7 +3,7 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   config.hosts << 'hoshi-ni-task-wo.net'
   config.hosts << 'hoshi-ni-task-wo.onrender.com'
-  config.hosts << 'hoshi-ni-task-wo-pr-259.onrender.com'
+  config.hosts << 'hoshi-ni-task-wo-pr-260.onrender.com'
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.


### PR DESCRIPTION
<!-- github copilot レビューは日本語でお願いします -->
# 概要
<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->

タスク作成・更新モーダルでの星座選択に関する2つのバグを修正しました。
1. 完了済み星座が選択肢に含まれる問題
2. 星座詳細画面からのタスク作成後に星座選択がリセットされる問題

# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイントです -->

- app
  - controllers
    - tasks_controller.rb +4, -2
      - createメソッドで@milestonesを未完了のみに限定
      - updateメソッドで@milestonesを未完了のみに限定
      - @from_milestone_show変数を追加してparams[:milestone_id]の存在を判定
      - indexメソッドとの一貫性を保つ
  - views
    - tasks
      - create.turbo_stream.erb +2, -2
        - タスク作成成功時にfrom_milestone_showパラメータを渡すように修正
        - タスク作成失敗時も同様にfrom_milestone_showパラメータを渡すように修正
        - 星座詳細画面からの作成時に星座選択状態を維持


## スクリーンショット

<!-- Command + Shift + Control + 4 でスクリーンショットして Command + V でここに貼り付けるのが楽。以下のテーブルは必要に応じて使ってください -->

<!-- github copilot レビューは日本語でお願いします -->
