### PR TITLE
Test/limited sharing test

### DIFF
--- a/spec/factories/limited_sharing_milestones.rb
+++ b/spec/factories/limited_sharing_milestones.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     progress { Faker::Number.between(from: 0, to: 1) }
     color { "#FFDF5E" }
     start_date { Faker::Date.between(from: 1.year.ago, to: Date.today) }
-    end_date { Faker::Date.between(from: Date.today, to: 1.year.from_now) }
+    end_date { start_date + rand(1..365).days }
     completed_comment { Faker::Lorem.sentence(word_count: 5) }
     is_on_chart { false }
     association :user
@@ -14,9 +14,18 @@ FactoryBot.define do
     trait :completed do
       progress { 2 } # completed
       completed_comment { Faker::Lorem.sentence(word_count: 5) }
+    end
 
-      trait :with_tasks do
-        create_list { :limited_sharing_task }
+    trait :with_tasks do
+      transient do
+        tasks_count { 3 }
+      end
+
+      after(:create) do |milestone, evaluator|
+        create_list(:limited_sharing_task, evaluator.tasks_count,
+                    limited_sharing_milestone_id: milestone.id,
+                    user: milestone.user,
+                    create_milestone: false)
       end
     end
   end

--- a/spec/factories/limited_sharing_tasks.rb
+++ b/spec/factories/limited_sharing_tasks.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     description { Faker::Lorem.paragraph }
     progress { Faker::Number.between(from: 0, to: 2) }
     start_date { Faker::Date.between(from: 1.year.ago, to: Date.today) }
-    end_date { Faker::Date.between(from: Date.today, to: 1.year.from_now) }
+    end_date { start_date + rand(1..365).days }
     association :user
 
     # limited_sharing_milestone_idをセットするために必要な関連付け
@@ -17,6 +17,23 @@ FactoryBot.define do
       if evaluator.create_milestone
         limited_sharing_task.limited_sharing_milestone_id = create(:limited_sharing_milestone).id
       end
+    end
+
+    trait :not_started do
+      progress { :not_started }
+    end
+
+    trait :in_progress do
+      progress { :in_progress }
+    end
+
+    trait :completed do
+      progress { :completed }
+    end
+
+    trait :no_dates do
+      start_date { nil }
+      end_date { nil }
     end
   end
 end

--- a/spec/models/limited_sharing_milestone_spec.rb
+++ b/spec/models/limited_sharing_milestone_spec.rb
@@ -1,0 +1,215 @@
+require "rails_helper"
+
+RSpec.describe LimitedSharingMilestone, type: :model do
+  let(:user) { create(:user) }
+
+  describe "validation" do
+    subject { build(:limited_sharing_milestone, user: user) }
+
+    it "factoryが有効であること" do
+      expect(subject).to be_valid
+    end
+
+    describe "presence validations" do
+      it { should validate_presence_of(:title) }
+      it { should validate_presence_of(:progress) }
+      it { should validate_presence_of(:color) }
+      it { should validate_presence_of(:user_id) }
+    end
+  end
+
+  describe "associations" do
+    it { should belong_to(:user) }
+    it { should belong_to(:constellation).optional }
+    it { should have_many(:tasks).dependent(:destroy).class_name("LimitedSharingTask") }
+  end
+
+  describe "enums" do
+    it { should define_enum_for(:progress).with_values(not_started: 0, in_progress: 1, completed: 2) }
+  end
+
+  describe "instanceメソッド" do
+    let(:milestone) { create(:limited_sharing_milestone, user: user) }
+
+    describe "#completed_tasks_percentage" do
+      context "タスクがない場合" do
+        it "0を返すこと" do
+          expect(milestone.completed_tasks_percentage).to eq(0)
+        end
+      end
+
+      context "一部のタスクが完了している場合" do
+        let(:milestone_with_mixed_tasks) do
+          create(:limited_sharing_milestone, :with_tasks,
+                 user: user, tasks_count: 2)
+        end
+
+        before do
+          milestone_with_mixed_tasks.tasks.first
+                                    .update(progress: :completed)
+          milestone_with_mixed_tasks.tasks.second
+                                    .update(progress: :not_started)
+        end
+
+        it "正しい完了率を返すこと" do
+          expect(milestone_with_mixed_tasks.completed_tasks_percentage)
+            .to eq(50)
+        end
+      end
+
+      context "すべてのタスクが完了している場合" do
+        let(:milestone_with_completed_tasks) do
+          create(:limited_sharing_milestone, :with_tasks, user: user, tasks_count: 2)
+        end
+
+        before do
+          milestone_with_completed_tasks.tasks
+                                        .each do |task|
+                                          task.update(progress: :completed)
+                                        end
+        end
+
+        it "100を返すこと" do
+          expect(milestone_with_completed_tasks.completed_tasks_percentage)
+            .to eq(100)
+        end
+      end
+    end
+
+    describe "#open?" do
+      it "常にtrueを返すこと" do
+        expect(milestone.open?).to be true
+      end
+    end
+
+    describe "#on_chart?" do
+      it "is_on_chartがtrueの場合trueを返すこと" do
+        milestone.update(is_on_chart: true)
+        expect(milestone.on_chart?).to be true
+      end
+
+      it "is_on_chartがfalseの場合falseを返すこと" do
+        milestone.update(is_on_chart: false)
+        expect(milestone.on_chart?).to be false
+      end
+    end
+  end
+
+  describe "NanoidGenerator concern" do
+    describe "#set_id" do
+      it "初期化時にユニークなIDが設定されること" do
+        milestone = build(:limited_sharing_milestone, user: user)
+        milestone.save
+        expect(milestone.id).to be_present
+        expect(milestone.id.length).to eq(21)
+      end
+
+      it "IDが既に設定されている場合は変更されないこと" do
+        existing_id = "existing_test_id_123"
+        milestone = build(:limited_sharing_milestone, user: user, id: existing_id)
+        milestone.save
+        expect(milestone.id).to eq(existing_id)
+      end
+    end
+
+    describe ".generate_nanoid" do
+      it "指定された長さのIDを生成すること" do
+        id = LimitedSharingMilestone.generate_nanoid(size: 10)
+        expect(id.length).to eq(10)
+      end
+
+      it "指定された文字セットを使用すること" do
+        id = LimitedSharingMilestone.generate_nanoid(alphabet: "abc123",
+                                                     size: 10)
+        expect(id).to match(/\A[abc123]+\z/)
+      end
+    end
+  end
+
+  describe "factory" do
+    describe ":limited_sharing_milestone" do
+      it "有効な限定共有マイルストーンを作成すること" do
+        milestone = create(:limited_sharing_milestone)
+        expect(milestone).to be_valid
+      end
+
+      it "デフォルトでチャート表示がfalseであること" do
+        milestone = build(:limited_sharing_milestone)
+        expect(milestone.is_on_chart).to be false
+      end
+    end
+
+    describe ":completed trait" do
+      it "完了状態のマイルストーンを作成すること" do
+        milestone = build(:limited_sharing_milestone, :completed)
+        expect(milestone.progress).to eq("completed")
+        expect(milestone.completed_comment).to be_present
+      end
+    end
+
+    describe ":with_tasks trait" do
+      it "関連するタスクを持つマイルストーンを作成すること" do
+        milestone = create(:limited_sharing_milestone, :with_tasks)
+        expect(milestone.tasks.count).to eq(3)
+        milestone.tasks.each do |task|
+          expect(task).to be_a(LimitedSharingTask)
+          expect(task.user).to eq(milestone.user)
+        end
+      end
+
+      it "タスク数をカスタマイズできること" do
+        milestone = create(:limited_sharing_milestone, :with_tasks, tasks_count: 5)
+        expect(milestone.tasks.count).to eq(5)
+      end
+    end
+  end
+
+  describe "タスクとの連携" do
+    let(:milestone_with_tasks) { create(:limited_sharing_milestone, user: user) }
+
+    it "マイルストーンが削除されると関連するタスクも削除されること" do
+      create(:limited_sharing_task, user: user,
+                                    limited_sharing_milestone_id: milestone_with_tasks.id,
+                                    create_milestone: false)
+      create(:limited_sharing_task, user: user,
+                                    limited_sharing_milestone_id: milestone_with_tasks.id,
+                                    create_milestone: false)
+
+      expect { milestone_with_tasks.destroy }
+        .to change(LimitedSharingTask, :count).by(-2)
+    end
+
+    it "タスクの進捗に基づいて完了率が正しく計算されること" do
+      milestone_with_percentage = create(:limited_sharing_milestone,
+                                         :with_tasks, user: user,
+                                                      tasks_count: 5)
+
+      # 2つ完了、1つ進行中、2つ未着手に設定
+      milestone_with_percentage.tasks[0].update(progress: :completed)
+      milestone_with_percentage.tasks[1].update(progress: :completed)
+      milestone_with_percentage.tasks[2].update(progress: :in_progress)
+      milestone_with_percentage.tasks[3].update(progress: :not_started)
+      milestone_with_percentage.tasks[4].update(progress: :not_started)
+
+      expect(milestone_with_percentage.completed_tasks_percentage)
+        .to eq(40) # 2/5 = 40%
+    end
+  end
+
+  describe "Constellation関連" do
+    let(:constellation) { create(:constellation) }
+
+    it "星座を関連付けることができること" do
+      milestone = create(:limited_sharing_milestone, user: user,
+                                                     constellation: constellation)
+      expect(milestone.constellation).to eq(constellation)
+    end
+
+    it "星座なしでも有効であること" do
+      milestone = create(:limited_sharing_milestone, user: user,
+                                                     constellation: nil)
+      expect(milestone).to be_valid
+      expect(milestone.constellation).to be_nil
+    end
+  end
+end

--- a/spec/models/limited_sharing_task_spec.rb
+++ b/spec/models/limited_sharing_task_spec.rb
@@ -1,0 +1,224 @@
+require "rails_helper"
+
+RSpec.describe LimitedSharingTask, type: :model do
+  let(:user) { create(:user) }
+  let(:milestone) { create(:limited_sharing_milestone, user: user) }
+
+  describe "validation" do
+    subject do
+      build(:limited_sharing_task, user: user, limited_sharing_milestone_id: milestone.id, create_milestone: false)
+    end
+
+    it "factoryが有効であること" do
+      expect(subject).to be_valid
+    end
+
+    describe "presence validations" do
+      it { should validate_presence_of(:title) }
+      it { should validate_presence_of(:progress) }
+      it { should validate_presence_of(:limited_sharing_milestone_id) }
+    end
+  end
+
+  describe "associations" do
+    it do
+      should belong_to(:milestone)
+        .class_name("LimitedSharingMilestone")
+        .with_foreign_key("limited_sharing_milestone_id")
+    end
+    it { should belong_to(:user) }
+  end
+
+  describe "enums" do
+    it { should define_enum_for(:progress).with_values(not_started: 0, in_progress: 1, completed: 2) }
+  end
+
+  describe "scope" do
+    describe ".valid_dates_nil" do
+      let!(:task_with_dates) do
+        create(:limited_sharing_task, user: user,
+                                      limited_sharing_milestone_id: milestone.id,
+                                      start_date: Date.new(2025, 6, 1),
+                                      end_date: Date.new(2025, 6, 10),
+                                      create_milestone: false)
+      end
+      let!(:task_without_dates) do
+        create(:limited_sharing_task, :no_dates, user: user,
+                                                 limited_sharing_milestone_id: milestone.id,
+                                                 create_milestone: false)
+      end
+
+      it "両方の日付がnilでないタスクのみを返すこと" do
+        expect(LimitedSharingTask.valid_dates_nil).to include(task_with_dates)
+        expect(LimitedSharingTask.valid_dates_nil).not_to include(task_without_dates)
+      end
+    end
+
+    describe ".start_date_asc" do
+      let!(:early_task) do
+        create(:limited_sharing_task, user: user,
+                                      limited_sharing_milestone_id: milestone.id,
+                                      start_date: Date.new(2025, 1, 1),
+                                      create_milestone: false)
+      end
+      let!(:late_task) do
+        create(:limited_sharing_task, user: user,
+                                      limited_sharing_milestone_id: milestone.id,
+                                      start_date: Date.new(2025, 6, 1),
+                                      create_milestone: false)
+      end
+
+      it "開始日の昇順でタスクを並べ替えること" do
+        results = LimitedSharingTask.where(id: [early_task.id, late_task.id])
+                                    .start_date_asc
+        expect(results.first).to eq(early_task)
+        expect(results.last).to eq(late_task)
+      end
+    end
+  end
+
+  describe "instanceメソッド" do
+    let(:completed_milestone) do
+      create(:limited_sharing_milestone, user: user, progress: :completed)
+    end
+    let(:task) do
+      create(:limited_sharing_task, user: user,
+                                    limited_sharing_milestone_id: completed_milestone.id,
+                                    create_milestone: false)
+    end
+
+    describe "#milestone_completed?" do
+      it "マイルストーンが完了している場合trueを返すこと" do
+        expect(task.milestone_completed?).to be true
+      end
+
+      it "マイルストーンが未完了の場合falseを返すこと" do
+        completed_milestone.update(progress: :not_started)
+        expect(task.milestone_completed?).to be false
+      end
+
+      it "マイルストーンがnilの場合falseを返すこと" do
+        task.update(limited_sharing_milestone_id: nil)
+        expect(task.milestone_completed?).to be false
+      end
+    end
+
+    describe "#completed?" do
+      it "進捗が完了の場合trueを返すこと" do
+        task.update(progress: :completed)
+        expect(task.completed?).to be true
+      end
+
+      it "進捗が未完了の場合falseを返すこと" do
+        task.update(progress: :not_started)
+        expect(task.completed?).to be false
+      end
+    end
+
+    describe "#in_progress?" do
+      it "進捗が進行中の場合trueを返すこと" do
+        task.update(progress: :in_progress)
+        expect(task.in_progress?).to be true
+      end
+
+      it "進捗が進行中でない場合falseを返すこと" do
+        task.update(progress: :completed)
+        expect(task.in_progress?).to be false
+      end
+    end
+
+    describe "#not_started?" do
+      it "進捗が未着手の場合trueを返すこと" do
+        task.update(progress: :not_started)
+        expect(task.not_started?).to be true
+      end
+
+      it "進捗が未着手でない場合falseを返すこと" do
+        task.update(progress: :in_progress)
+        expect(task.not_started?).to be false
+      end
+    end
+  end
+
+  describe "NanoidGenerator concern" do
+    let(:user) { create(:user) }
+    let(:milestone) { create(:limited_sharing_milestone, user: user) }
+
+    describe "#set_id" do
+      it "初期化時にユニークなIDが設定されること" do
+        task = build(:limited_sharing_task, user: user,
+                                            limited_sharing_milestone_id: milestone.id,
+                                            create_milestone: false)
+        task.save
+        expect(task.id).to be_present
+        expect(task.id.length).to eq(21)
+      end
+
+      it "IDが既に設定されている場合は変更されないこと" do
+        existing_id = "existing_test_id_123"
+        task = build(:limited_sharing_task, user: user,
+                                            limited_sharing_milestone_id: milestone.id,
+                                            id: existing_id, create_milestone: false)
+        task.save
+        expect(task.id).to eq(existing_id)
+      end
+    end
+
+    describe ".generate_nanoid" do
+      it "指定された長さのIDを生成すること" do
+        id = LimitedSharingTask.generate_nanoid(size: 10)
+        expect(id.length).to eq(10)
+      end
+
+      it "指定された文字セットを使用すること" do
+        id = LimitedSharingTask.generate_nanoid(alphabet: "abc123",
+                                                size: 10)
+        expect(id).to match(/\A[abc123]+\z/)
+      end
+    end
+  end
+
+  describe "factory" do
+    describe ":limited_sharing_task" do
+      it "有効な限定共有タスクを作成すること" do
+        task = create(:limited_sharing_task)
+        expect(task).to be_valid
+      end
+
+      it "関連するマイルストーンが自動作成されること" do
+        task = create(:limited_sharing_task)
+        expect(task.milestone).to be_present
+        expect(task.milestone).to be_a(LimitedSharingMilestone)
+      end
+    end
+
+    describe ":not_started trait" do
+      it "未着手状態のタスクを作成すること" do
+        task = build(:limited_sharing_task, :not_started)
+        expect(task.progress).to eq("not_started")
+      end
+    end
+
+    describe ":in_progress trait" do
+      it "進行中状態のタスクを作成すること" do
+        task = build(:limited_sharing_task, :in_progress)
+        expect(task.progress).to eq("in_progress")
+      end
+    end
+
+    describe ":completed trait" do
+      it "完了状態のタスクを作成すること" do
+        task = build(:limited_sharing_task, :completed)
+        expect(task.progress).to eq("completed")
+      end
+    end
+
+    describe ":no_dates trait" do
+      it "日付が設定されていないタスクを作成すること" do
+        task = build(:limited_sharing_task, :no_dates)
+        expect(task.start_date).to be_nil
+        expect(task.end_date).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
  <!-- github copilot レビューは日本語でお願いします -->
  # 概要

  LimitedSharingTaskとLimitedSharingMilestoneモデルの包括的なテストファイルを新規作成し、factoryファイルの問題を修正しました。
  NanoidGenerator concernの共有機能やマイルストーン・タスク間の複雑な関係性を含む全機能を網羅しました。

  # 細かな変更点

  - spec
    - models
      - limited_sharing_task_spec.rb 新規作成
        - 【validation】presence、limited_sharing_milestone_idの必須チェック
        - 【associations】milestone、userとの関連テスト（外部キー指定含む）
        - 【enums】progressの状態管理テスト
        - 【scope】valid_dates_nil、start_date_ascの動作テスト
        - 【instanceメソッド】milestone_completed?、completed?、in_progress?、not_started?テスト
        - 【NanoidGenerator】set_id、generate_nanoidのID生成機能テスト
        - 【factory】基本とtrait（not_started、in_progress、completed、no_dates）テスト
      - limited_sharing_milestone_spec.rb 新規作成
        - 【validation】presence、user_id必須チェック
        - 【associations】user、constellation、tasksとの関連テスト
        - 【enums】progressの状態管理テスト
        - 【instanceメソッド】completed_tasks_percentage、open?、on_chart?テスト
        - 【NanoidGenerator】共有ID生成機能の完全テスト
        - 【factory】基本とtrait（completed、with_tasks）テスト
        - 【連携テスト】タスク削除の依存関係、完了率計算テスト
        - 【Constellation関連】星座との関連付けテスト
    - factories
      - limited_sharing_tasks.rb 修正
        - 【バリデーション修正】end_dateがstart_dateより前になる問題を修正
        - 【trait追加】progress状態とno_datesパターンのtrait追加
      - limited_sharing_milestones.rb 修正
        - 【バリデーション修正】日付の論理的整合性問題を解決
        - 【trait修正】with_tasksの実装不備を修正し適切な関連作成
      
  ## 追加した機能
  - **限定共有モデル完全テスト**: 両モデル合計56テストケース
  - **NanoidGenerator concern**: 21文字のユニークID生成機能テスト
  - **複雑な関連性テスト**: 
    - milestone ↔ task の双方向依存関係
    - 削除時のカスケード動作確認
    - 進捗状態に基づく完了率計算
  - **スコープ機能テスト**: 日付フィルタリング、並び替え機能
  - **Factory最適化**: trait活用による効率的なテストデータ作成

  ## 品質改善とコードレビュー対応
  - **コード重複削除**: let定義の最適化、冗長なfactory呼び出し整理
  - **テスト名改善**: スコープ名と実際の動作の整合性確保
  - **Factory活用**: beforeブロックからtraitを使った宣言的記述へ変更
  - **固定日付使用**: テスト安定性確保のためDate.newを使用
  - **userテストスタイル統一**: 日本語describe/it文、一貫したセクション構造

  <!-- github copilot レビューは日本語でお願いします -->
